### PR TITLE
Process updates from feedback

### DIFF
--- a/PROCESS.md
+++ b/PROCESS.md
@@ -1,0 +1,86 @@
+## Interchain Standardization Process
+
+Inter-chain standardization will follow an adaptation of the [TC 39](https://tc39.github.io/process-document/) process used by the ECMAScript steering committee.
+
+#### Stage 0 - `Strawman`
+- _**Purpose**_: Start the specification process
+- _**Entrance Criteria**_: [Open an issue](https://github.com/cosmos/ics/issues/new) on this repository with a short outline of your proposal and a specification nane.
+- _**Acceptance Signifies**_: No acceptance required to move to the next stage. Keep the issue around to track the specification status, and close it when the final specification is merged or the proposal abandoned.
+- _**Spec Quality**_: Outline only. Link to any prior documentation, discussion, or reference materials.
+- _**Changes Expected Post-Acceptance**_: N/A
+- _**Implementation Types Expected**_: None required, but link to any existing
+
+#### Stage 1 - `Proposal`
+- _**Purpose**_:
+  * Make the case for the addition of this specification to the Cosmos ecosystem
+  * Describe the shape of the a potential solution
+  * Identify challenges to this proposal
+- _**Entrance Criteria**_:
+  * Prose outlining the problem or need and the general shape of a solution in a PR to a `./spec/ics-{{ .Spec.Number }}-{{ .Spec.Name }}/README.md` file in this repo. This file should contain:
+    1. List of expected projects & users within the Cosmos ecosystem who might make use of the specification along with any particular requirements they have
+    1. Discussion of key algorithms, abstractions, and semantics
+    1. High-level application interface outline, where applicable
+    1. Identification of potential design tradeoffs and implementation challenges/complexity
+  * Identified `Champion(s)` who will advance the proposal
+- _**Acceptance Signifies**_:
+  * The PR has received two approvals from members of the specification team.
+- _**Spec Quality**_:
+  * Follows the structure laid out in ICS 1 and provides a reasonable overview of the proposed addition.
+- _**Changes Expected Post-Acceptance**_:
+  * Major, the entire shape of the solution may change. Proposal documents are not to be relied upon for implementation.
+- _**Implementation Types Expected**_:
+  * Tightly bounded demos, example repos showing reproduction steps for issues fixed by proposal
+
+#### Stage 2 - `Draft`
+- _**Purpose**_:
+  * Precisely describe the syntax and semantics using formal spec language
+- _**Entrance Criteria**_:
+  * Everything from stage 1
+  * Initial specification text in a PR to update the `./spec/{{ .Spec.Number }}-{{ .Spec.Name }}/README.md` file
+  * Any additional reference documentation or media in the `./spec/{{ .Spec.Number }}-{{ .Spec.Name }}` directory
+- _**Acceptance Signifies**_:
+  * The specification team expects that this proposal will be finalized and eventually included in the ICS standard set
+- _**Spec Quality**_:
+  * Draft: all major semantics, syntax and API are covered, but TODOs, placeholders and editorial issues are expected
+- _**Changes Expected Post-Acceptance**_:
+  * Incremental changes expected after spec enters draft stage. Implementors should work with the spec champions as work continues on spec development.
+- _**Implementation Types Expected**_:
+  * Experimental
+
+#### Stage 3 - `Candidate`
+- _**Purpose**_:
+  * Indicate that further refinement will require feedback from implementations and users
+- _**Entrance Criteria**_:
+  * Everything from stages 1,2
+  * Complete specification text
+  * At least one spec compatible implementation exists
+- _**Acceptance Signifies**_:
+  * The solution is complete and no further work is possible without implementation experience, significant usage and external feedback.
+- _**Spec Quality**_:
+  * Complete: all semantics, syntax and API are completed described
+- _**Changes Expected Post-Acceptance**_:
+  * Limited: only those deemed critical based on implementation experience
+- _**Implementation Types Expected**_:
+  * Specification-compliant
+
+#### Stage 4 - `Finalized`
+- _**Purpose**_:
+  * Indicate that the addition is included in the formal ICS system
+- _**Entrance Criteria**_:
+  * Everything from stages 1,2,3
+  * At least two specification-compatible implementations exist, and they have been tested against each other
+  * All relevant ecosystem stakeholders approve the specification (any holdout can block this stage)
+  * Acceptance tests are written and merged into the Cosmos-SDK and other relevant downstream repositories
+  * All files in the `./spec/{{ .Spec.Number }}-{{ .Spec.Name}}/` directory are up to date and merged into the `cosmos/ics` repo
+- _**Acceptance Signifies**_:
+  * The addition is now part of the ICS standard set
+- _**Spec Quality**_:
+  * Final: All changes as a result of implementation experience are integrated
+- _**Changes Expected Post-Acceptance**_:
+  * None
+- _**Implementation Types Expected**_:
+  * Shipping/Production
+
+### Calls for implementation and feedback
+
+When an addition is accepted at the “candidate” (stage 3) maturity level, the committee is signifying that it believes design work is complete and further refinement will require implementation experience, significant usage and external feedback.

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -2,78 +2,71 @@
 
 Inter-chain standardization will follow an adaptation of the [TC 39](https://tc39.github.io/process-document/) process used by the ECMAScript steering committee.
 
-#### Stage 0 - `Strawman`
+#### Stage 1 - `Strawman`
+
 - _**Purpose**_: Start the specification process
 - _**Entrance Criteria**_: [Open an issue](https://github.com/cosmos/ics/issues/new) on this repository with a short outline of your proposal and a specification nane.
-- _**Acceptance Signifies**_: No acceptance required to move to the next stage. Keep the issue around to track the specification status, and close it when the final specification is merged or the proposal abandoned.
+- _**Acceptance Requirements**_: No acceptance required to move to the next stage. Keep the issue around to track the specification status, and close it when the final specification is merged or the proposal abandoned.
 - _**Spec Quality**_: Outline only. Link to any prior documentation, discussion, or reference materials.
 - _**Changes Expected Post-Acceptance**_: N/A
 - _**Implementation Types Expected**_: None required, but link to any existing
 
-#### Stage 1 - `Proposal`
+#### Stage 2 - `Draft`
+
 - _**Purpose**_:
   * Make the case for the addition of this specification to the Cosmos ecosystem
   * Describe the shape of the a potential solution
   * Identify challenges to this proposal
 - _**Entrance Criteria**_:
-  * Prose outlining the problem or need and the general shape of a solution in a PR to a `./spec/ics-{{ .Spec.Number }}-{{ .Spec.Name }}/README.md` file in this repo. This file should contain:
+  * Prose outlining the problem or need and the general shape of a solution in a PR to a `./spec/ics-{{ .Spec.Number }}-{{ .Spec.Name }}/README.md` file in this repo.
+    This file should contain:
     1. List of expected projects & users within the Cosmos ecosystem who might make use of the specification along with any particular requirements they have
     1. Discussion of key algorithms, abstractions, and semantics
     1. High-level application interface outline, where applicable
     1. Identification of potential design tradeoffs and implementation challenges/complexity
-  * Identified `Champion(s)` who will advance the proposal
-- _**Acceptance Signifies**_:
-  * The PR has received two approvals from members of the specification team.
+    See [ICS 1](spec/ics-1-ics-standard) for a more detailed description of standard requirements.
+  * Identified `author(s)` who will advance the proposal in the header of the standard file
+  * Any additional reference documentation or media in the `./spec/{{ .Spec.Number }}-{{ .Spec.Name }}` directory
+  * The specification team expects that this proposal will be finalized and eventually included in the ICS standard set.
 - _**Spec Quality**_:
   * Follows the structure laid out in ICS 1 and provides a reasonable overview of the proposed addition.
+- _**Acceptance Requirements**_:
+  * The PR has received two approvals from members of the core specification team, at which point it can be merged into the ICS repository.
 - _**Changes Expected Post-Acceptance**_:
-  * Major, the entire shape of the solution may change. Proposal documents are not to be relied upon for implementation.
+  * Changes to details but not to the key concepts are expected after a standard enters draft stage. Implementors should work with the spec authors as work continues on spec development.
 - _**Implementation Types Expected**_:
   * Tightly bounded demos, example repos showing reproduction steps for issues fixed by proposal
 
-#### Stage 2 - `Draft`
-- _**Purpose**_:
-  * Precisely describe the syntax and semantics using formal spec language
-- _**Entrance Criteria**_:
-  * Everything from stage 1
-  * Initial specification text in a PR to update the `./spec/{{ .Spec.Number }}-{{ .Spec.Name }}/README.md` file
-  * Any additional reference documentation or media in the `./spec/{{ .Spec.Number }}-{{ .Spec.Name }}` directory
-- _**Acceptance Signifies**_:
-  * The specification team expects that this proposal will be finalized and eventually included in the ICS standard set
-- _**Spec Quality**_:
-  * Draft: all major semantics, syntax and API are covered, but TODOs, placeholders and editorial issues are expected
-- _**Changes Expected Post-Acceptance**_:
-  * Incremental changes expected after spec enters draft stage. Implementors should work with the spec champions as work continues on spec development.
-- _**Implementation Types Expected**_:
-  * Experimental
-
 #### Stage 3 - `Candidate`
+
 - _**Purpose**_:
   * Indicate that further refinement will require feedback from implementations and users
 - _**Entrance Criteria**_:
-  * Everything from stages 1,2
+  * Everything from stages 1 & 2
   * Complete specification text
-  * At least one spec compatible implementation exists
-- _**Acceptance Signifies**_:
+  * At least one specification-compatible implementation exists
+  * All relevant ecosystem stakeholders have been given a chance to review and provide feedback on the standard
   * The solution is complete and no further work is possible without implementation experience, significant usage and external feedback.
 - _**Spec Quality**_:
   * Complete: all semantics, syntax and API are completed described
+- _**Acceptance Requirements**_:
+  * The PR changing the stage to "candidate" has been approved by two members of the core specification team.
 - _**Changes Expected Post-Acceptance**_:
-  * Limited: only those deemed critical based on implementation experience
+  * Limited: only those deemed critical based on implementation experiences.
 - _**Implementation Types Expected**_:
   * Specification-compliant
 
 #### Stage 4 - `Finalized`
 - _**Purpose**_:
-  * Indicate that the addition is included in the formal ICS system
+  * Indicate that the addition is included in the formal ICS standard set
 - _**Entrance Criteria**_:
   * Everything from stages 1,2,3
   * At least two specification-compatible implementations exist, and they have been tested against each other
   * All relevant ecosystem stakeholders approve the specification (any holdout can block this stage)
   * Acceptance tests are written and merged into the Cosmos-SDK and other relevant downstream repositories
   * All files in the `./spec/{{ .Spec.Number }}-{{ .Spec.Name}}/` directory are up to date and merged into the `cosmos/ics` repo
-- _**Acceptance Signifies**_:
-  * The addition is now part of the ICS standard set
+- _**Acceptance Requirements**_:
+  * The PR changing the stage to "finalized" has been approved by representatives from all relevant ecosystem stakeholders, and all members of the core specification team.
 - _**Spec Quality**_:
   * Final: All changes as a result of implementation experience are integrated
 - _**Changes Expected Post-Acceptance**_:

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -57,6 +57,7 @@ Inter-chain standardization will follow an adaptation of the [TC 39](https://tc3
   * Specification-compliant
 
 #### Stage 4 - `Finalized`
+
 - _**Purpose**_:
   * Indicate that the addition is included in the formal ICS standard set
 - _**Entrance Criteria**_:

--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 ## Synopsis
 
-This repository is the canonical location for development and documentation of inter-chain standards utilized by the Cosmos ecosystem. Initially it will be used to consolidate design documentation for the inter-blockchain communication protocol (IBC), encoding standards for Cosmos chains, and miscellaneous utilities such as off-chain message signing.
+This repository is the canonical location for development and documentation of inter-chain standards utilized by the Cosmos network & interchain ecosystem. Initially it will be used to consolidate design documentation for the inter-blockchain communication protocol (IBC), encoding standards for Cosmos chains, and miscellaneous utilities such as off-chain message signing.
 
 ## Standardization
 
 Please see [ICS 1](spec/ics-1-ics-standard) for a description of what a standard entails.
 
-To start a new standardization document, copy the [template](spec/ics-template.md). See [PROCESS.md](PROCESS.md) for a description of the standardization process.
+To propose a new standard, [open an issue](https://github.com/cosmos/ics/issues/new). To start a new standardization document, copy the [template](spec/ics-template.md) and open a PR.
+
+See [PROCESS.md](PROCESS.md) for a description of the standardization process.
 
 ## Interchain Standards
 

--- a/README.md
+++ b/README.md
@@ -1,92 +1,19 @@
 # Interchain Standards Development
 
+## Synopsis
+
 This repository is the canonical location for development and documentation of inter-chain standards utilized by the Cosmos ecosystem. Initially it will be used to consolidate design documentation for the inter-blockchain communication protocol (IBC), encoding standards for Cosmos chains, and miscellaneous utilities such as off-chain message signing.
 
-Inter-chain standardization will follow an adaptation of the [TC 39](https://tc39.github.io/process-document/) process used by the ECMAScript steering committee.
+## Standardization
 
 Please see [ICS 1](spec/ics-1-ics-standard) for a description of what a standard entails.
 
-To start a new standardization document, copy the [template](spec/ics-template.md).
+To start a new standardization document, copy the [template](spec/ics-template.md). See [PROCESS.md](PROCESS.md) for a description of the standardization process.
 
-## Cosmos Interchain Specification Proposal Process
+## Interchain Standards
 
-#### Stage 0 - `Strawman`
-- _**Purpose**_: Start the specification process
-- _**Entrance Criteria**_: [Open an issue](https://github.com/cosmos/ics/issues/new) on this repository with a short outline of your proposal and a specification nane.
-- _**Acceptance Signifies**_: No acceptance required to move to the next stage. Keep the issue around to track the specification status, and close it when the final specification is merged or the proposal abandoned.
-- _**Spec Quality**_: Outline only. Link to any prior documentation, discussion, or reference materials.
-- _**Changes Expected Post-Acceptance**_: N/A
-- _**Implementation Types Expected**_: None required, but link to any existing
+All standards in the "draft" stage are listed here in order of their ICS numbers.
 
-#### Stage 1 - `Proposal`
-- _**Purpose**_:
-  * Make the case for the addition of this specification to the Cosmos ecosystem
-  * Describe the shape of the a potential solution
-  * Identify challenges to this proposal
-- _**Entrance Criteria**_:
-  * Prose outlining the problem or need and the general shape of a solution in a PR to a `./spec/ics-{{ .Spec.Number }}-{{ .Spec.Name }}/README.md` file in this repo. This file should contain:
-    1. List of expected projects & users within the Cosmos ecosystem who might make use of the specification along with any particular requirements they have
-    1. Discussion of key algorithms, abstractions, and semantics
-    1. High-level application interface outline, where applicable
-    1. Identification of potential design tradeoffs and implementation challenges/complexity
-  * Identified `Champion(s)` who will advance the proposal
-- _**Acceptance Signifies**_:
-  * The PR has received 2 approvals from members of the specification team.
-- _**Spec Quality**_:
-  * None, this is just a proposal
-- _**Changes Expected Post-Acceptance**_:
-  * Major, the entire shape of the solution may change. Proposal documents are not to be relied upon for implementation.
-- _**Implementation Types Expected**_:
-  * Tightly bounded demos, example repos showing reproduction steps for issues fixed by proposal
-
-#### Stage 2 - `Draft`
-- _**Purpose**_:
-  * Precisely describe the syntax and semantics using formal spec language
-- _**Entrance Criteria**_:
-  * Everything from stage 1
-  * Initial specification text in a PR to update the `./spec/{{ .Spec.Number }}-{{ .Spec.Name }}/README.md` file
-  * Any additional reference documentation or media in the `./spec/{{ .Spec.Number }}-{{ .Spec.Name }}` directory
-- _**Acceptance Signifies**_:
-  * The specification team expects that this proposal will be finalized and eventually included in the standard
-- _**Spec Quality**_:
-  * Draft: all major semantics, syntax and API are covered, but TODOs, placeholders and editorial issues are expected
-- _**Changes Expected Post-Acceptance**_:
-  * Incremental changes expected after spec enters draft stage. Implementors should work with the spec champions as work continues on spec development.
-- _**Implementation Types Expected**_:
-  * Experimental
-
-#### Stage 3 - `Candidate`
-- _**Purpose**_:
-  * Indicate that further refinement will require feedback from implementations and users
-- _**Entrance Criteria**_:
-  * Everything from stages 1,2
-  * Complete specification text
-- _**Acceptance Signifies**_:
-  * The solution is complete and no further work is possible without implementation experience, significant usage and external feedback.
-- _**Spec Quality**_:
-  * Complete: all semantics, syntax and API are completed described
-- _**Changes Expected Post-Acceptance**_:
-  * Limited: only those deemed critical based on implementation experience
-- _**Implementation Types Expected**_:
-  * Spec compliant
-
-#### Stage 4 - `Finalized`
-- _**Purpose**_:
-  * Indicate that the addition is included in the formal ICS system
-- _**Entrance Criteria**_:
-  * Everything from stages 1,2,3
-  * Acceptance tests are written and merged into the Cosmos-SDK and other relevant downstream repositories
-  * At least one spec compatible implementation exists
-  * All files in the `./spec/{{ .Spec.Number }}-{{ .Spec.Name}}/` directory are up to date and merged into the `cosmos/ics` repo
-- _**Acceptance Signifies**_:
-  * The addition is now part of the ICS standard set
-- _**Spec Quality**_:
-  * Final: All changes as a result of implementation experience are integrated
-- _**Changes Expected Post-Acceptance**_:
-  * None
-- _**Implementation Types Expected**_:
-  * Shipping/Production
-
-### Calls for implementation and feedback
-
-When an addition is accepted at the “candidate” (stage 3) maturity level, the committee is signifying that it believes design work is complete and further refinement will require implementation experience, significant usage and external feedback.
+| Interchain Standard Number   | Standard Title             | Stage | Category |
+| ---------------------------- | -------------------------- | ----- | -------- |
+| [1](spec/ics-1-ics-standard) | ICS Specification Standard | Draft | Meta     |

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ See [PROCESS.md](PROCESS.md) for a description of the standardization process.
 
 ## Interchain Standards
 
-All standards in the "draft" stage are listed here in order of their ICS numbers.
+All standards in the "draft" stage are listed here in order of their ICS numbers, sorted by category.
 
-| Interchain Standard Number   | Standard Title             | Stage | Category |
-| ---------------------------- | -------------------------- | ----- | -------- |
-| [1](spec/ics-1-ics-standard) | ICS Specification Standard | Draft | Meta     |
+### Meta
+
+| Interchain Standard Number   | Standard Title             | Stage |
+| ---------------------------- | -------------------------- | ----- |
+| [1](spec/ics-1-ics-standard) | ICS Specification Standard | Draft |


### PR DESCRIPTION
Updates from feedback last week at the IBC ecosystem call:

- Move TC39 process description to separate file
- List merged draft-stage-or-later specifications in README
- Clarify required approvals at different process stages
- Clarify required dual-implementation compatibility before standard finalization

Also several other updates I think are prudent:

- Combines the "proposal" and "draft" stages, which don't seem necessary to separate
- Clarify what specific stages correspond to in terms of Git state / PR approvals / etc.