### PR TITLE
Fix 24/getConsensusState

### DIFF
--- a/spec/ics-024-host-requirements/README.md
+++ b/spec/ics-024-host-requirements/README.md
@@ -83,7 +83,7 @@ Host chains MUST provide the ability to introspect their own consensus state, wi
 type getConsensusState = (height: uint64) => ConsensusState
 ```
 
-`getConsensusState` is RECOMMENDED to return the consensus state for the consensus algorithm of the host chain at the specified height, for all heights greater than zero and less than or equal to the current height. `getConsensusState` MAY return the consensus state only for some number of recent heights.
+`getConsensusState` is RECOMMENDED to return the consensus state for the consensus algorithm of the host chain at the specified height, for all heights greater than zero and less than or equal to the current height. `getConsensusState` MAY return the consensus state only for some number of recent heights, where the number is constant for the host chain.
 
 ### Port system
 

--- a/spec/ics-024-host-requirements/README.md
+++ b/spec/ics-024-host-requirements/README.md
@@ -83,7 +83,7 @@ Host chains MUST provide the ability to introspect their own consensus state, wi
 type getConsensusState = (height: uint64) => ConsensusState
 ```
 
-`getConsensusState` MUST return the consensus state for the consensus algorithm of the host chain at the specified height, for all heights greater than zero and less than or equal to the current height.
+`getConsensusState` is RECOMMENDED to return the consensus state for the consensus algorithm of the host chain at the specified height, for all heights greater than zero and less than or equal to the current height. `getConsensusState` MAY return the consensus state only for some number of recent heights.
 
 ### Port system
 


### PR DESCRIPTION
Under `getConsensusState`,

> `getConsensusState` MUST return the consensus state for the consensus algorithm of the host chain at the specified height, for all heights greater than zero and less than or equal to the current height.

For some cases `getConsensusState` will not be able to return the consensus state with height of `0 < _ < current`. For efficiency, the chains might choose to prune the states and (if the pruning happens for past enough states) the impl will still work, so the restriction should be RECOMMENDED.