### PR TITLE
Fix Readme ibc protocol paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ See [PROCESS.md](PROCESS.md) for a description of the standardisation process.
 
 If you are planning to review inter-blockchain communication protocol specifications, the following are required reading:
 
-- [IBC Architecture](./ibc/1_IBC_ARCHITECTURE.md)
-- [IBC Design Principles](./ibc/2_IBC_DESIGN_PRINCIPLES.md)
-- [IBC Terminology](./ibc/3_IBC_TERMINOLOGY.md)
-- [IBC Usecases](./ibc/4_IBC_USECASES.md)
-- [IBC Design Patterns](./ibc/5_IBC_DESIGN_PATTERNS.md)
+-   [IBC Terminology](./ibc/1_IBC_TERMINOLOGY.md)
+-   [IBC Architecture](./ibc/2_IBC_ARCHITECTURE.md)
+-   [IBC Design Principles](./ibc/3_IBC_DESIGN_PRINCIPLES.md)
+-   [IBC Usecases](./ibc/4_IBC_USECASES.md)
+-   [IBC Design Patterns](./ibc/5_IBC_DESIGN_PATTERNS.md)
 
 ## Interchain Standards
 
@@ -42,17 +42,17 @@ All standards at or past the "Draft" stage are listed here in order of their ICS
 
 ### IBC/TAO
 
-| Interchain Standard Number                          | Standard Title                     | Stage |
-| --------------------------------------------------- | ---------------------------------- | ----- |
-| [2](spec/ics-002-client-semantics)                | Validity Predicate                 | Draft |
-| [3](spec/ics-003-connection-semantics)              | Connection Semantics               | Draft |
-| [4](spec/ics-004-channel-and-packet-semantics)      | Channel & Packet Semantics         | Draft |
-| [5](spec/ics-005-port-allocation)                   | Port Allocation                    | Draft |
-| [18](spec/ics-018-relayer-algorithms)               | Relayer Algorithms                 | Draft |
-| [23](spec/ics-023-vector-commitments)               | Vector Commitments                 | Draft |
-| [24](spec/ics-024-host-requirements)                | Host Requirements                  | Draft |
-| [25](spec/ics-025-handler-interface)                | Handler Interface                  | Draft |
-| [26](spec/ics-026-relayer-module)                   | Relayer Module                     | Draft |
+| Interchain Standard Number                     | Standard Title             | Stage |
+| ---------------------------------------------- | -------------------------- | ----- |
+| [2](spec/ics-002-client-semantics)             | Validity Predicate         | Draft |
+| [3](spec/ics-003-connection-semantics)         | Connection Semantics       | Draft |
+| [4](spec/ics-004-channel-and-packet-semantics) | Channel & Packet Semantics | Draft |
+| [5](spec/ics-005-port-allocation)              | Port Allocation            | Draft |
+| [18](spec/ics-018-relayer-algorithms)          | Relayer Algorithms         | Draft |
+| [23](spec/ics-023-vector-commitments)          | Vector Commitments         | Draft |
+| [24](spec/ics-024-host-requirements)           | Host Requirements          | Draft |
+| [25](spec/ics-025-handler-interface)           | Handler Interface          | Draft |
+| [26](spec/ics-026-relayer-module)              | Relayer Module             | Draft |
 
 ### IBC/APP
 


### PR DESCRIPTION
I have fixed paths for IBC specs in readme. 