### PR TITLE
Fix ics-027

### DIFF
--- a/spec/ics-027-interchain-account/README.md
+++ b/spec/ics-027-interchain-account/README.md
@@ -44,7 +44,7 @@ Also, each chain must know how the counterparty chains serialize/deserialize tra
 The chain must reject the transaction and must not make a state transition in the following cases:
 
 - The IBC transaction fails to be deserialized.
-- The IBC transaction expects signers other than the interchain accounts made by the counterparty chain..
+- The IBC transaction expects signers other than the interchain accounts made by the counterparty chain.
 
 It does not restrict how you can distinguish signers that was not made by the counterparty chain. But the most common way would be to record the account in state when the interchain account is registered and to verify that signers are recorded interchain account.
 

--- a/spec/ics-027-interchain-account/README.md
+++ b/spec/ics-027-interchain-account/README.md
@@ -75,7 +75,7 @@ interface RegisterIBCAccountPacketData {
 }  
 ```
 
-`RunTxPacketData` is used to execute a transaction on an interchain account. The transaction bytes contain the transaction itself & the appropriate signatures, and are serialised in a manner appropriate for the destination chain.
+`RunTxPacketData` is used to execute a transaction on an interchain account. The transaction bytes contain the transaction itself and are serialised in a manner appropriate for the destination chain.
 
 ```typescript  
 interface RunTxPacketData {  


### PR DESCRIPTION
I read carefully after merging. And I found some things needed to be fixed. 🙏
I removed  "the appropriate signatures" in the sentence "The transaction bytes contain the transaction itself & the appropriate signatures". And I fixed a typo that I found.
@cwgoes And, It seems that you use "serialise/deserialise". But, my English dictionary says it as "serialize/deserialize". I'm not sure that which one is correct or both are correct. But, I used "serialize/deserialize". So, there are two types of "serializ(s)e/deserializ(s)e" in this document. Do you think that it is better to use only "serialise/deserialise"?