### PR TITLE
DOC: small typos in ecosystem/README.md

### DIFF
--- a/ecosystem/README.md
+++ b/ecosystem/README.md
@@ -8,7 +8,7 @@ Currently the IBC working group is being actively led and managed by Tendermint 
 
 ### Structure
 
-Following each IBC working group meeting, an new issue for the next meeting will be created with a proposed agenda for comments and collaboration from the larger working group. During the two week timeframe between calls, we invite IBC working group members to contribute to the next meeting's agenda and join the bi-weekly call to discuss the topics in conjunction with the IBC core team. Upon concluding a meeting, a recording will be posted and the details and notes will be published in the associated issue and linked to in this file.
+Following each IBC working group meeting, a new issue for the next meeting will be created with a proposed agenda for comments and collaboration from the larger working group. During the two-week timeframe between calls, we invite IBC working group members to contribute to the next meeting's agenda and join the bi-weekly call to discuss the topics in conjunction with the IBC core team. Upon concluding a meeting, a recording will be posted and the details and notes will be published in the associated issue and linked to in this file.
 
 Inspired by [ethereum/pm](https://github.com/ethereum/pm).
 
@@ -22,4 +22,4 @@ Inspired by [ethereum/pm](https://github.com/ethereum/pm).
 
 ### Upcoming Meetings
 
-- January 16th, 2020 17:00 CET.
+- TBD


### PR DESCRIPTION
Edited two small typos in the text, and changed future meeting date to `TBD` since the one that was there has already happened.