### PR TITLE
Fix ICS04 to set right connection in verification

### DIFF
--- a/spec/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/ics-004-channel-and-packet-semantics/README.md
@@ -321,7 +321,7 @@ function chanOpenTry(
     abortTransactionUnless(connection !== null)
     abortTransactionUnless(connection.state === OPEN)
     expected = ChannelEnd{INIT, order, portIdentifier,
-                          channelIdentifier, connectionHops.reverse(), counterpartyVersion}
+                          channelIdentifier, [connection.counterpartyConnectionIdentifier], counterpartyVersion}
     abortTransactionUnless(connection.verifyChannelState(
       proofHeight,
       proofInit,
@@ -357,7 +357,7 @@ function chanOpenAck(
     abortTransactionUnless(connection !== null)
     abortTransactionUnless(connection.state === OPEN)
     expected = ChannelEnd{TRYOPEN, channel.order, portIdentifier,
-                          channelIdentifier, channel.connectionHops.reverse(), counterpartyVersion}
+                          channelIdentifier, [connection.counterpartyConnectionIdentifier], counterpartyVersion}
     abortTransactionUnless(connection.verifyChannelState(
       proofHeight,
       proofTry,
@@ -388,7 +388,7 @@ function chanOpenConfirm(
     abortTransactionUnless(connection !== null)
     abortTransactionUnless(connection.state === OPEN)
     expected = ChannelEnd{OPEN, channel.order, portIdentifier,
-                          channelIdentifier, channel.connectionHops.reverse(), channel.version}
+                          channelIdentifier, [connection.counterpartyConnectionIdentifier], channel.version}
     abortTransactionUnless(connection.verifyChannelState(
       proofHeight,
       proofAck,
@@ -446,7 +446,7 @@ function chanCloseConfirm(
     abortTransactionUnless(connection !== null)
     abortTransactionUnless(connection.state === OPEN)
     expected = ChannelEnd{CLOSED, channel.order, portIdentifier,
-                          channelIdentifier, channel.connectionHops.reverse(), channel.version}
+                          channelIdentifier, [connection.counterpartyConnectionIdentifier], channel.version}
     abortTransactionUnless(connection.verifyChannelState(
       proofHeight,
       proofInit,


### PR DESCRIPTION
`channelEnd.connectionHops` is supposed to mean its own connection. (not counterparty's)

It is possible to put a notable further work of 'reversed' hops semantics only if we query multiple connection first. (Doing so doesn't seem clear now I think)