### PR TITLE
Add omitted counterpartyPrefix field in the ConnOpenTry datagram

### DIFF
--- a/spec/ics-018-relayer-algorithms/README.md
+++ b/spec/ics-018-relayer-algorithms/README.md
@@ -96,6 +96,7 @@ function pendingDatagrams(chain: Chain, counterparty: Chain): List<Set<Datagram>
         desiredIdentifier: localEnd.counterpartyConnectionIdentifier,
         counterpartyConnectionIdentifier: localEnd.identifier,
         counterpartyClientIdentifier: localEnd.clientIdentifier,
+        counterpartyPrefix: localEnd.commitmentPrefix,
         clientIdentifier: localEnd.counterpartyClientIdentifier,
         version: localEnd.version,
         counterpartyVersion: localEnd.version,


### PR DESCRIPTION
The `connOpenTry` function in the channel spec has`counterpartyPrefix` argument, but the `ConnOpenTry` datagram does not have it.

```
function connOpenTry(
  desiredIdentifier: Identifier,
  counterpartyConnectionIdentifier: Identifier,
  **counterpartyPrefix**: CommitmentPrefix,
  counterpartyClientIdentifier: Identifier,
```