### PR TITLE
docs: IBC terminology link fix

### DIFF
--- a/ibc/1_IBC_TERMINOLOGY.md
+++ b/ibc/1_IBC_TERMINOLOGY.md
@@ -52,7 +52,7 @@ A *commitment proof* is the proof structure which proves whether a particular ke
 
 ### Handler Module
 
-The IBC *handler module* is the module within the state machine which implements [ICS 25](../spec/ics-025-handler-module), managing clients, connections, & channels, verifying proofs, and storing appropriate commitments for packets.
+The IBC *handler module* is the module within the state machine which implements [ICS 25](../spec/ics-025-handler-interface), managing clients, connections, & channels, verifying proofs, and storing appropriate commitments for packets.
 
 ### Routing Module
 


### PR DESCRIPTION
Fix broken ICS 25 link in "Handler Module" section.