### PR TITLE
Path typo fix

### DIFF
--- a/spec/ics-024-host-requirements/README.md
+++ b/spec/ics-024-host-requirements/README.md
@@ -120,7 +120,7 @@ Note that the client-related paths listed below reflect the Tendermint client as
 | -------------- | ------------------------------------------------------------------------------ | ----------------- | ---------------------- |
 | provableStore  | "clients/{identifier}/clientType"                                              | ClientType        | [ICS 2](../ics-002-client-semantics) |
 | privateStore   | "clients/{identifier}/clientState"                                             | ClientState       | [ICS 2](../ics-007-tendermint-client) |
-| provableStore  | "clients/{identifier}/consensusState/{height}"                                 | ConsensusState    | [ICS 7](../ics-007-tendermint-client) |
+| provableStore  | "clients/{identifier}/consensusStates/{height}"                                | ConsensusState    | [ICS 7](../ics-007-tendermint-client) |
 | privateStore   | "clients/{identifier}/connections                                              | []Identifier      | [ICS 3](../ics-003-connection-semantics) |
 | provableStore  | "connections/{identifier}"                                                     | ConnectionEnd     | [ICS 3](../ics-003-connection-semantics) |
 | privateStore   | "ports/{identifier}"                                                           | CapabilityKey     | [ICS 5](../ics-005-port-allocation) |


### PR DESCRIPTION
According to ICS 7, the correct Path is `"clients/{identifier}/consensusStates/{height}"` (plural).