### PR TITLE
Add definition for Acknowledgement Envelope

### DIFF
--- a/spec/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/ics-004-channel-and-packet-semantics/README.md
@@ -683,10 +683,10 @@ function acknowledgePacket(
 
 ##### Acknowledgement Envelope
 
-The acknowledgement returned from the remote chain is defined as arbitrary bytes in the ics protocol. This data
+The acknowledgement returned from the remote chain is defined as arbitrary bytes in the IBC protocol. This data
 may either encode a successful execution or a failure (anything besides a timeout). There is no generic way to
-distinguish the two cases, which require any client-side packet visualizer to understand every app-specific protocol
-in order to distinguish the case of successful or failed relay. In order to reduce this issue, we offer additional
+distinguish the two cases, which requires that any client-side packet visualizer understands every app-specific protocol
+in order to distinguish the case of successful or failed relay. In order to reduce this issue, we offer an additional
 specification for acknowledgement formats, which [SHOULD](https://www.ietf.org/rfc/rfc2119.txt) be used by the 
 app-specific protocols.
 
@@ -699,10 +699,10 @@ message Acknowledgement {
 }
 ```
 
-If an application uses a different format for acknowledge bytes, it MUST not deserialize to a valid protobuf message
+If an application uses a different format for acknowledgement bytes, it MUST not deserialize to a valid protobuf message
 of this format. Note that all packets contain exactly one non-empty field, and it must be result or error.  The field
 numbers 21 and 22 were explicitly chosen to avoid accidental conflicts with other protobuf message formats used
-for acknowledgements. The first byte of any message with this format will be the non-ascii values `0xaa` (result) 
+for acknowledgements. The first byte of any message with this format will be the non-ASCII values `0xaa` (result) 
 or `0xb2` (error).
 
 #### Timeouts


### PR DESCRIPTION
Closes #461 

This adds a recommended Acknowledgement envelope to the packet specification along with the definition of the acknowledgement algorithm.

I propose this under the RFC2119 keyword "SHOULD"

> 3. SHOULD   This word, or the adjective "RECOMMENDED", mean that there
>   may exist valid reasons in particular circumstances to ignore a
>   particular item, but the full implications must be understood and
>   carefully weighed before choosing a different course.

If you disagree with that, it could be reduced to "MAY":

> 5. MAY   This word, or the adjective "OPTIONAL", mean that an item is
>    truly optional.  One vendor may choose to include the item because a
>    particular marketplace requires it or because the vendor feels that
>    it enhances the product while another vendor may omit the same item.
>    An implementation which does not include a particular option MUST be
>    prepared to interoperate with another implementation which does
>    include the option, though perhaps with reduced functionality. In the
>    same vein an implementation which does include a particular option
>    MUST be prepared to interoperate with another implementation which
>    does not include the option (except, of course, for the feature the
>    option provides.)

However, I think much of the utility for allowing intelligent client-side code in a dynamic IBC world would be reduced by watering it down from "SHOULD". Likewise I feel it is not so essential to warrant MUST/SHALL.