### PR TITLE
Fix syntax highlighting codeblock of ics-005

### DIFF
--- a/spec/ics-005-port-allocation/README.md
+++ b/spec/ics-005-port-allocation/README.md
@@ -131,32 +131,32 @@ function callingModuleIdentifier(): SourceIdentifier {
 
 `newCapability`, `authenticateCapability`, `claimCapability`, `getCapability`, and `releaseCapability` are then implemented as follows:
 
-```
+```typescript
 function newCapability(name: string): CapabilityKey {
   return callingModuleIdentifier()
 }
 ```
 
-```
+```typescript
 function authenticateCapability(name: string, capability: CapabilityKey) {
   return callingModuleIdentifier() === name
 }
 ```
 
-```
+```typescript
 function claimCapability(name: string, capability: CapabilityKey) {
   // no-op
 }
 ```
 
-```
+```typescript
 function getCapability(name: string): CapabilityKey {
   // not actually used
   return nil
 }
 ```
 
-```
+```typescript
 function releaseCapability(capability: CapabilityKey) {
   // no-op
 }


### PR DESCRIPTION
When I was reading the spec/isc-005 , I found a code block that was not colored, so I fixed it.
https://github.com/cosmos/ics/tree/master/spec/ics-005-port-allocation