### PR TITLE
Cross-chain valset update spec

### DIFF
--- a/spec/app/ics-028-cross-chain-valset-update/README.md
+++ b/spec/app/ics-028-cross-chain-valset-update/README.md
@@ -1,0 +1,257 @@
+# Technical Specification
+
+## Introduction
+
+This document presents a technical specification for the **Cross-Chain Validation** protocol.
+The basic idea of the Cross-Chain Validation protocol is to allow validators that are already securing some existing blockchain (parent blockchain) to also secure a "new" blockchain (baby blockchain).
+The stake bonded at the parent blockchain guarantees that a validator behaves correctly at the baby blockchain.
+Otherwise, the validator is slashed on the parent blockchain.
+
+Therefore, at a high level, we can imagine the Cross-Chain Validation protocol to be concerned with following entities:
+  - Parent blockchain: This is a blockchain that "provides" validators. Namely, "provided" validators have some stake at the parent blockchain. Any misbehavior of a validator is slashed at the parent blockchain. Moreover, parent blockchain manipulates the validator set of a chain that "borrows" validators from it.
+  - Baby blockchain: Baby blockchain is a blockchain that is being secured by the parent blockchain. In other words, validators that secure and operate the baby blockchain are bonded on the parent blockchain. Any misbehavior of a validator at the baby blockchain is punished at the parent blockchain (i.e., the validator is slashed at the parent blockchain).
+  - Causally consistent shared FIFO queue: This queue is used for communication among two blockchains, as we explain in the rest of the document.
+
+Note that the protocol we present is generalized to multiple baby blockchains.
+In other words, a single parent blockchain might have multiple baby blockchains under its "jurisdiction".
+Hence, the Cross-Chain Validation protocol is concerned with more than two entities (one parent blockchain and potentially multiple baby blockchains).
+
+### Properties
+
+This subsection is devoted to defining properties that the Cross-Chain Validation protocol ensures.
+Recall that the parent blockchain has an ability to demand a change to the validator set of the baby chain.
+Moreover, we want to ensure the stake of validators of the baby blockchain are "frozen" at the parent chain.
+
+We present the interface of the protocol:
+  - Request: <ChangeValidatorSet, babyChain, V> - request made by the parent blockchain to change the validator set of babyChain using the validator set updates V.
+  We assume that each validator set update is unique (e.g., each validator set update V could simply have a unique identifier).
+  - Indication: <Unbonded, babyChain, V> - indication to the parent blockchain that the validator set update V (i.e., its "effect") has unbonded on the baby blockchain.
+
+Hence, we aim to achieve the following properties:
+- *Liveness*: If the parent blockchain demands a validator set change V for the baby chain, then the validator set of the baby blockchain reflects this demand.
+- *Validator set change safety*: Suppose that the validator set of the baby blockchain changes from *V* to *V'*. Then, there exists a sequence *seq = V1, V2, ..., Vn*, where *n > 0*, of change validator set demands issued by the parent blockchain such that *apply(V, seq) = V'*.
+- *Validator set change liveness*: If there exist infinitely many <ChangeValidatorSet, babyChain, V'> issued after <ChangeValidatorSet, babyChain, V>, then <Unbonded, babyChain, V> is eventually triggered.
+
+Let us explain the validator set change liveness property.
+First, note that <Unbonded, babyChain, Vlast> is never triggered if Vlast represent the **final** validator set change demand issued by the parent blockchain (the reason is that the validator set of the baby blockchain will never change after Vlast).
+Hence, it might be enough for V not to be the last demanded change.
+Unfortunatelly, that is not the case since multiple validator set change demands might be committed in the same block as the last demand.
+That is why we demand infinitely many demands to be issued after V.
+Note that if B represents the number of transactions committed in each block, then it is sufficient to demand B validator set change demands to be issued in order for V to eventually unbond.
+
+## High-level design of the Cross-Chain Validation protocol
+
+In this section, we provide an intuition behind our protocol.
+
+We use the causally consistent FIFO queue for "communication" among two blockchains (parent and baby).
+Namely, the parent blockchain enqueues new validator set changes and the baby blockchain dequeues these validator set changes once they have unbonded on the baby blockchain (which represents a signal that the stake of those validator could be set free by the parent blockchain).
+
+- Parent blockchain: Once the parent blockchain demands a change of validator set, it enqueues the validator set.
+
+- Baby blockchain: Once the baby blockchain observes that there exist new validator set demands, the baby blockchain applies all these changes.
+Moreover, whenever the validator set of the baby blockchain is modified, the "old" validator set should start unbonding.
+That is the baby blockchain uses the **local** *UnbondingQueue* queue.
+Namely, whenever the validator set of the baby blockchain is modified, we enqueue to *UnbondingQueue* the sequence number of the validator set change demand that was **last** applied in order to obtain the old (i.e., changed) validator set.
+Once the unbonding period elapses for the validator set, the appropriate entry is dequeued from the shared queue.
+
+## Data Structures
+
+We devote this section to defining the data structures used to represent the states of both parent and baby blockchain, as well as the packets exchanged by the two blockchains.
+
+### Application data
+
+#### Parent blockchain
+
+- Q: The causally consistent FIFO shared queue.
+
+#### Baby blockchain
+
+- Q: The causally consistent FIFO shared queue.
+- *UnbondingQueue*: Keeps track of validators that are currently unbonding.
+- validatorSetSeqNum: Number of validator set change demands processed; initialized to 0.
+- dequeueSeqNum: Number of elements dequeued from Q; initialized to 0.
+- lastObserved: Element of Q that was observed during the last Q.read() operation; initializated to nil.
+
+## Transitions
+
+In this section, we informally discuss the state transitions that occur in our protocol.
+We observe state transitions that are driven by a user (i.e., the new staking module on the parent chain), driven by the relayer and driven by elapsed time.
+
+  - User-driven state transitions: These transitions "start" the entire process of changing the validator set of the baby blockchain.
+  We assume that the will to change the validator set of the baby blockchain babyChain is expressed by invoking <ChangeValidatorSet, babyChain, V>.
+
+  - Time-driven state transitions: These transitions are activated since some time has elapsed. As we will present in the rest of the document, time-driven state transitions help us determine when the unbonding period, measured at the baby blockchain, has elapsed for a validator set.
+
+In the rest of the document, we will discuss the aforementioned state transitions in more detail.
+
+## Function Definitions
+
+### Parent blockchain
+
+This subsection will present the functions executed at the parent blockchain.
+
+```golang
+// expresses will to modify the validator set of the baby blockchain;
+func changeValidatorSet(
+  babyChainId: ChainId
+  valSetUpdate: Validator[]
+) {
+  // enqueue to the queue shared with babyChainId
+  Q[babyChainId].enqueue(valSetUpdate)
+}
+```
+
+- Expected precondition
+  - There exists a blockchain with *babyChainId* identifier
+  - All validators from *valSetUpdate* are validators at the parent blockchain
+- Expected postcondition
+  - The valSetUpdate is enqueued to the queue shared with the blockchain with *babyChainId*
+- Error condition
+  - If the precondition is violated
+
+TODO discuss and write a staking logic on endBlock
+Important: By reading the shared queue Q, the parent blockchain is able to conclude which validators could get their stake back.
+
+### Baby blockchain
+
+```golang
+// initialization function
+func init() {
+  UnbondingQueue = new local FIFO queue
+  validatorSetSeqNum = 0
+  dequeueSeqNum = 0
+  lastObserved = nil
+}
+```
+
+
+```golang
+// function used in End-Block method
+// returns all the elements enqueued since the last invocation of this method
+func observeChangesQ() { 
+  // get the content of the shared queue
+  content = Q.read()
+
+  // check whether the last observed element is in content
+  if (!content.has(lastObserved)) {
+    // update the lastObserved to the last element of content if content is not empty
+    if (!content.empty()) lastObserved = content.last()
+
+    // return the entire content
+    return content
+  } else {
+    // set "old" lastObserved
+    oldLastObserved = lastObserved
+
+    // update the lastObserved to the last element of content
+    lastObserved = content.last()
+
+    // return the entire content of content starting from oldLastObserved (excluding oldLastObserved)
+    return content.startFrom(oldLastObserved)
+  }
+}
+```
+
+- Expected precondition
+  - None
+- Expected postcondition
+  - Returns the elements enqueued since the last Q.read() operation was invoked.
+- Error condition
+  - None
+
+```golang
+// End-Block method executed at the end of each block
+func endBlock(block: Block) {
+  // get time
+  time = block.time
+
+  // finish unbonding for mature validator sets
+  while (!UnbondingQueue.isEmpty()) {
+    // peak the first queue entry
+    seqNum, startTime = UnbondingQueue.peak()
+
+    if (startTime + UNBONDING_PERIOD >= time) {
+      // remove from the unbonding queue
+      seqNum, startTime = UnbondingQueue.dequeue()
+
+      // dequeue all elements until seqNum
+      for (i = dequeueSeqNum + 1; i <= seqNum; i++) {
+        Q.dequeue()
+      }
+      dequeueSeqNum = seqNum
+
+    } else {
+      break
+    }
+  }
+
+  // get the new changes
+  changes = observeChangesQ()
+
+  // if there are no changes, return currnt validator set
+  if (changes.empty()) {
+    // validator set remains the same
+    ABCI.updateValidatorSet(block.validatorSet)
+    return
+  }
+
+  // get the old validator set
+  oldValSet = block.validatorSet
+
+  // get the new validator set; init to the old one
+  newValSet = oldValSet
+
+  // start unbonding for the old validator set represented by the validator set update;
+  // "start unbonding" simply means adding to the queue of validator set changes that started unbonding
+  UnbondingQueue.enqueue(validatorSetSeqNum, time)
+
+  // update the validator set
+  while (!changes.isEmpty()) {
+    valSetUpdate = changes.dequeue()
+
+    // update the new validator set
+    newValSet = applyValidatorUpdate(newValSet, valSetUpdate)
+
+    // increment validatorSetSeqNum
+    validatorSetSeqNum++
+
+    // remember which demands participate
+    if (content.isEmpty()) {
+      newSeqNum = validatorSetSeqNum
+    }
+  }
+
+  return newValSet
+}
+```
+
+- Expected precondition
+  - Every transaction from the *block* is executed
+- Expected postcondition
+  - Unbonding starts for the old validator set
+  - Unbonding finishes for all validator set that started unbonding more than *unbondingTime* before *time = block.time*. Moreover, the *UnbondingOver* packet is created for each such validator set
+  - The new validator set *newValSet* is pushed to the Tendermint protocol and *newValSet* reflects all the change validator set demands from the *block*
+- Error condition
+  - If the precondition is violated
+
+
+## Correctness Arguments
+
+Here we provide correctness arguments for the liveness, validator set change safety and liveness properties.
+
+### Liveness
+Suppose that the IBC communication indeed successfully relays the change validator set demand to the baby blockchain.
+Therefore, the validator set of the baby blockchain should reflect this demand.
+This indeed happens at the end of a block, since every observed demand is applied in order for the baby blockchain to calculate the new validator set.
+Hence, the property is satisfied.
+
+### Validator set change safety
+Suppose that the validator set of the baby blockchain changes from *V* to *V'* in two consecutive blocks.
+By construction of the protocol, we conclude that there exists a sequence of change validator set demands issued by the parent blockchain that result in *V'* when applied to *V*.
+Recursively, we conclude that this holds for any two validator sets (irrespectively of the "block distance" between them).
+
+### Validator set change liveness
+
+Since infinitely many demands are issued after the demand V, we conclude that eventually the unbonding period is started for V.
+The unbonding period eventually elapses and the V is dequeued at that moment.
+As soon as the dequeued is "observed" by the parent blockchain, the indication is triggered.

--- a/spec/app/ics-028-cross-chain-valset-update/README.md
+++ b/spec/app/ics-028-cross-chain-valset-update/README.md
@@ -8,7 +8,7 @@ The stake bonded at the parent blockchain guarantees that a validator behaves co
 Otherwise, the validator is slashed on the parent blockchain.
 
 Therefore, at a high level, we can imagine the Cross-Chain Validation protocol to be concerned with following entities:
-  - Parent blockchain: This is a blockchain that "provides" validators. Namely, "provided" validators have some stake at the parent blockchain. Any misbehavior of a validator is slashed at the parent blockchain. Moreover, parent blockchain manipulates the validator set of a chain that "borrows" validators from it.
+  - Parent blockchain: This is a blockchain that "provides" validators. Namely, "provided" validators have some stake at the parent blockchain. Any misbehavior of a validator is slashed on the parent blockchain. Moreover, the parent blockchain manipulates the validator set of a chain that "borrows" validators from it.
   - Baby blockchain: Baby blockchain is a blockchain that is being secured by the parent blockchain. In other words, validators that secure and operate the baby blockchain are bonded on the parent blockchain. Any misbehavior of a validator at the baby blockchain is punished at the parent blockchain (i.e., the validator is slashed at the parent blockchain).
   - Causally consistent shared FIFO queue: This queue is used for communication among two blockchains, as we explain in the rest of the document.
 

--- a/spec/app/ics-028-cross-chain-valset-update/README.md
+++ b/spec/app/ics-028-cross-chain-valset-update/README.md
@@ -265,7 +265,6 @@ Recursively, we conclude that this holds for any two validator sets (irrespectiv
 
 ### Validator set change liveness
 
-<<<<<<< HEAD
 Since the demand V is not the last issued demand, we conclude that eventually the maturing period is started for V.
 The maturing period eventually elapses and the V is acknowledged at that moment.
 As soon as the acknowledgement is "observed" by the parent blockchain, the indication is triggered.
@@ -296,12 +295,3 @@ Hence, the following mechanism for the parent blockchain to discover which valid
 	- However, if there is a validator set change in IssuedChanges that "removes" a validator, this validator cannot take its money back. The reason is that this validator set change might not have reached the baby blockchain yet.
 
 Hence, the parent blockchain needs to take into account the worst possible scenario in order to remain perfectly secure throughout the execution.
-
-
-
-
-=======
-Since infinitely many demands are issued after the demand V, we conclude that eventually the unbonding period is started for V.
-The unbonding period eventually elapses and the V is dequeued at that moment.
-As soon as the dequeued is "observed" by the parent blockchain, the indication is triggered.
->>>>>>> 5bdd01fb817b64a3a4369b6a019a2d3df282a823

--- a/spec/app/ics-028-cross-chain-valset-update/README.md
+++ b/spec/app/ics-028-cross-chain-valset-update/README.md
@@ -9,7 +9,7 @@ Otherwise, the validator is slashed on the parent blockchain.
 
 Therefore, at a high level, we can imagine the Cross-Chain Validation protocol to be concerned with following entities:
   - Parent blockchain: This is a blockchain that "provides" validators. Namely, "provided" validators have some stake at the parent blockchain. Any misbehavior of a validator is slashed on the parent blockchain. Moreover, the parent blockchain manipulates the validator set of a chain that "borrows" validators from it.
-  - Baby blockchain: Baby blockchain is a blockchain that is being secured by the parent blockchain. In other words, validators that secure and operate the baby blockchain are bonded on the parent blockchain. Any misbehavior of a validator at the baby blockchain is punished at the parent blockchain (i.e., the validator is slashed at the parent blockchain).
+  - Baby blockchain: The baby blockchain is a blockchain that is being secured by the parent blockchain. In other words, validators that secure and operate the baby blockchain are bonded on the parent blockchain. Any misbehavior of a validator at the baby blockchain is punished by the parent blockchain (i.e., the validator is slashed on the parent blockchain).
   - Causally consistent shared FIFO queue: This queue is used for communication among two blockchains, as we explain in the rest of the document.
 
 Note that the protocol we present is generalized to multiple baby blockchains.

--- a/spec/app/ics-070-shared-queue/README.md
+++ b/spec/app/ics-070-shared-queue/README.md
@@ -1,0 +1,485 @@
+# Queue Module
+
+## Introduction
+
+This document presents a technical specification of the **queue module**.
+The queue module contains a logic necessary for implementing shared FIFO queue among two parties (i.e., two blockchains).
+Therefore, in an implementation of the FIFO queue we are interested in, the following entities take place:
+  - Two blockchains: Each validator of each blockchain implements its queue module.
+  We say that one blockchain is the parent blockchain, whereas the other is the baby blockchain.
+  - IBC communication: There exists an IBC communication among two aforementioned blockchains.
+  Blockchains communicate exclusively using the IBC channels among them.
+
+We present two versions of the queue module.
+The versions provide slightly different interface and guarantees, as we describe in the following subsection.
+
+### Shared FIFO Queue Specification
+
+Our shared FIFO queue is a concurrent object.
+We now define both versions of our queue.
+
+#### Sequential Consistent FIFO Queue
+
+The first "version" of the queue - which is denote by Sequential Consistent FIFO queue (SCQ) - exposes the following interface:
+- *enqueue(x)* operation: Operation that enqueues the element *x* to the queue.
+- *dequeue()* operation: Operation that dequeues the first element of the queue and returns that element.
+- *peak()* operation: Operation that returns the first element of the queue without removing it.
+- *contains(x)* operation: Operation that returns whether the element *x* belongs to the queue.
+
+We set the following constraints:
+- Enqueue and contains operations are invoked solely by the parent blockchain.
+- Dequeue and peak operations are invoked solely by the baby blockchain.
+
+Lastly, our implementation satisfies the **sequential consistency** correctness criterium:
+The result of any execution is the same as if the operations of all the processes were executed in some sequential order, and the operations of each individual process appear in this sequence in the order specified by its protocol.
+
+#### Causally Consistent FIFO Queue
+
+We denote the second version of our FIFO queue by Causally Consistent FIFO Queue (CCQ), which exposes the following interface:
+- *enqueue(x)* operation: Operation that enqueues the element *x* to the queue.
+- *dequeue()* operation: Operation that dequeues the first element of the queue and returns that element.
+- *read()* operation: Operation that returns the "content" of the entire queue.
+
+We introduce the following constraints:
+- Enqueue operations are invoked solely by the parent blockchain.
+- Dequeue operations are invoked solely by the baby blockchain.
+
+Note the difference between causally and sequentially consistent FIFO queue in their interface.
+The SCQ exposes the peak and contains operations (that are invoked solely by the baby and parent blockchain, respectivelly), whereas CCQ exposes the read operation (that can be invoked by both blockchains).
+Note that read operation of the CCQ could be used to implement the peak and contains operations (i.e., the read operation could be reduced to the peak and contains operations).
+However, we show that the approach used for implementing SCQ, which is sequentially consistent, **cannot** be used for implementing sequentially consistent queue with the read operation.
+
+Thus, CCQ satisfies the **causal consistency** correctness criterium.
+Let us first define the causal precedence relation:
+Consider operations A and B.
+We say that A *causally precedes* B (we write "A --> B") if and only if:
+1) A and B are invoked by the same blockchain and A is invoked before B, or
+2) A is a write operation and the blockchain that invokes B has observed A before invoking B, or
+3) There exists an operation C such that A --> C and C --> B.  
+Moreover, operations A and B are *concurrent* if neither causally precedes the other.
+
+Finally, we are able to define the causal consistency correctness criterium.
+Operations that are related by the causal precedence relation are observed by all parties (i.e., blockchains) in their causal precedence order.
+Note that the definition allows concurrent operations to be seen in different order by different blockchains.
+
+### Closer Look at the IBC Channels
+
+An IBC channel assumes two parties (the respective blockchains) involved in the communication. However, it also assumes a relayer which handles message transmissions between the two blockchains. The relayer carries a central responsibility in ensuring communication between the two parties through the channel.
+
+A relayer intermediates communication between the two blockchains. Each blockchain exposes an API comprising read, write, as well as a queue (FIFO) functionality. So there are two parts to the communication API:
+
+- a read/write store: The read/write store holds the entire state of the chain. Each module can write to this store.
+- a queue of datagrams (packets): Each module can dequeue datagrams stored in this queue and a relayer can queue to this queue.
+
+## High-Level Design of the Shared FIFO Queue
+
+In this section, we provide an intuition behind our protocols.
+Since both SCQ and CCQ are implemented in the fairly similar fashion, we do not distinguish the two here.
+
+First, each blockchain maintains a local copy Q of our FIFO shared queue.
+
+Let us first explain how we implement the write operations (i.e., enqueue and dequeue operations).
+Firstly, the blockchain that has invoked a write operation executes the operation on its local copy.
+Then, it informs the other blockchain about the operation using the IBC channel between the two blockchains.
+Lastly, the operation completes once the invoking blockchain receives an IBC acknowledgment for the sent packet.
+
+As for the read operations (peak and contains in SCQ, or read in CCQ), an invoking blockchain simply performs the read operation on its local copy.
+Note that no communication between blockchain occurs in case of read operations.
+
+## Data Structures
+
+We devote this section to defining the data structures used to represent the states of both parent and baby blockchain, as well as the packets exchanged by the two blockchains.
+
+### Application data
+
+#### The parent blockchain
+
+- Q: Local copy of the shared FIFO queue.
+- Number: Map <Element, Integer> that takes note of how many instances of a specific element are present in the local copy of Q (used exclusively in the implementation of contains operations in SCQ).
+- Outcoming data store: "Part" of the blockchain observable for the relayer. Namely, each packet written in outcoming data store will be relayed by the relayer.
+
+#### The baby blockchain
+
+- Q: Local copy of the shared FIFO queue.
+- Outcoming data store: "Part" of the blockchain observable for the relayer. Namely, each packet written in outcoming data store will be relayed by the relayer.
+
+### Packet data
+
+- OperationPacket: Packet sent by an invoking blockchain to the other blockchain and encapsulates an invoked operation.
+More specifically, the packet has three parameters: 1) a unique identifier of the operation (can be blockchain id + sequence number), 2) type of the operation, and 3) a parameter (enqueued element in the case of an enqueue operation or dequeued element in the case of a dequeue operation).
+
+*Remark:* There exists the default acknowledgment packet for the OperationPacket.
+
+## Implementation
+
+### Port & channel setup
+
+The `setup` function must be called exactly once when the module is created
+to bind to the appropriate port.
+
+```golang
+func setup() {
+  capability = routingModule.bindPort("cross-chain staking", ModuleCallbacks{
+    onChanOpenInit,
+    onChanOpenTry,
+    onChanOpenAck,
+    onChanOpenConfirm,
+    onChanCloseInit,
+    onChanCloseConfirm,
+    onRecvPacket,
+    onTimeoutPacket,
+    onAcknowledgePacket,
+    onTimeoutPacketClose
+  })
+  claimCapability("port", capability)
+}
+```
+
+Once the `setup` function has been called, channels can be created through the IBC routing module
+between instances of the cross-chain staking modules on mother and daughter chains.
+
+##### Channel lifecycle management
+
+Mother and daughter chains accept new channels from any module on another machine, if and only if:
+
+- The channel being created is ordered.
+- The version string is `icsXXX`.
+
+```golang
+func onChanOpenInit(
+  order: ChannelOrder,
+  connectionHops: [Identifier],
+  portIdentifier: Identifier,
+  channelIdentifier: Identifier,
+  counterpartyPortIdentifier: Identifier,
+  counterpartyChannelIdentifier: Identifier,
+  version: string) {
+  // only ordered channels allowed
+  abortTransactionUnless(order === ORDERED)
+  // assert that version is "icsXXX"
+  abortTransactionUnless(version === "icsXXX")
+}
+```
+
+```golang
+func onChanOpenTry(
+  order: ChannelOrder,
+  connectionHops: [Identifier],
+  portIdentifier: Identifier,
+  channelIdentifier: Identifier,
+  counterpartyPortIdentifier: Identifier,
+  counterpartyChannelIdentifier: Identifier,
+  version: string,
+  counterpartyVersion: string) {
+  // only ordered channels allowed
+  abortTransactionUnless(order === ORDERED)
+  // assert that version is "icsXXX"
+  abortTransactionUnless(version === "icsXXX")
+  abortTransactionUnless(counterpartyVersion === "icsXXX")
+}
+```
+
+```golang
+func onChanOpenAck(
+  portIdentifier: Identifier,
+  channelIdentifier: Identifier,
+  version: string) {
+  // port has already been validated
+  // assert that version is "icsXXX"
+  abortTransactionUnless(version === "icsXXX")
+}
+```
+
+```golang
+func onChanOpenConfirm(
+  portIdentifier: Identifier,
+  channelIdentifier: Identifier) {
+  // accept channel confirmations, port has already been validated, version has already been validated
+}
+```
+
+```golang
+func onChanCloseInit(
+  portIdentifier: Identifier,
+  channelIdentifier: Identifier) {
+  // the channel is closing, do we need to punish?
+}
+```
+
+```golang
+func onChanCloseConfirm(
+  portIdentifier: Identifier,
+  channelIdentifier: Identifier) {
+  // the channel is closed, do we need to punish?
+}
+```
+
+### The parent blockchain
+
+```golang
+func enqueue(x: Element) {
+  // enqueue x locally
+  Q.enqueue(x)
+
+  // increase the number of occurrences of x; just for SCQ
+  Number[x] = Number[x] + 1
+
+  // create the OperationPacket packet
+  OperationPacket packet = OperationPacket{uniqueOperationId, "enqueue", x}
+
+  // obtain the destination port of the consumer
+  destPort = getPort(babyChainId)
+
+  // send the packet
+  handler.sendPacket(Packet{timeoutHeight, timeoutTimestamp, destPort, destChannel, sourcePort, sourceChannel, packet}, getCapability("port"))
+}
+```
+
+- Expected precondition
+  - None
+- Expected postcondition
+  - The element x is enqueued in the local copy of the queue.
+  - The number of occurrences of x is incremented.
+  - The OperationPacket is created
+- Error condition
+  - If the precondition is violated
+
+```golang
+func contains(x: Element) {
+  return Number[x] > 0
+}
+```
+
+- Expected precondition
+  - None
+- Expected postcondition
+  - None
+- Error condition
+  - If the precondition is violated
+
+```golang
+func read() {
+  return Q
+}
+``` 
+
+- Expected precondition
+  - None
+- Expected postcondition
+  - None
+- Error condition
+  - If the precondition is violated
+
+```golang
+func onRecvPacket(packet: Packet) {
+  // the packet is of OperationPacket type
+  assert(packet.type = OperationPacket)
+
+  // the packet is for a dequeue operation
+  assert(packet.operation = "dequeue")
+
+  // get x
+  x = packet.value
+
+  // remove the first appearance of x from the local copy
+  Q.remove(x)
+
+  // decrease the number of occurrences of x
+  Number[x] = Number[x] - 1
+
+  // construct the default acknowledgment
+  ack = defaultAck(OperationPacket)
+  return ack
+}
+```
+
+- Expected precondition
+  - The packet is sent to the parent by the baby blockchain
+  - The packet is of *OperationPacket* type
+  - The packet is for a dequeue operation
+- Expected postcondition
+  - The element x is removed from the local copy
+  - The number of occurrences of x is decremented
+- Error condition
+  - If the precondition is violated
+
+### The baby blockchain
+
+```golang
+func dequeue() {
+  // dequeue locally
+  x = Q.dequeue()
+
+  // create the OperationPacket packet
+  OperationPacket packet = OperationPacket{uniqueOperationId, "dequeue", x}
+
+  // obtain the destination port of the consumer
+  destPort = getPort(parentChainId)
+
+  // send the packet
+  handler.sendPacket(Packet{timeoutHeight, timeoutTimestamp, destPort, destChannel, sourcePort, sourceChannel, packet}, getCapability("port"))
+
+  return x
+}
+```
+
+- Expected precondition
+  - None
+- Expected postcondition
+  - The element x is dequeued from the local copy of the queue.
+  - The number of occurrences of x is decremented.
+  - The OperationPacket is created
+- Error condition
+  - If the precondition is violated
+
+```golang
+func peak() {
+  return Q.peak()
+}
+```
+
+- Expected precondition
+  - None
+- Expected postcondition
+  - None
+- Error condition
+  - If the precondition is violated
+
+```golang
+func read() {
+  return Q
+}
+``` 
+
+- Expected precondition
+  - None
+- Expected postcondition
+  - None
+- Error condition
+  - If the precondition is violated
+
+```golang
+func onRecvPacket(packet: Packet) {
+  // the packet is of OperationPacket type
+  assert(packet.type = OperationPacket)
+
+  // the packet is for an enqueue operation
+  assert(packet.operation = "enqueue")
+
+  // get x
+  x = packet.value
+
+  // enqueue x
+  Q.enqueue(x)
+
+  // construct the default acknowledgment
+  ack = defaultAck(OperationPacket)
+  return ack
+}
+```
+
+- Expected precondition
+  - The packet is sent to the parent by the baby blockchain
+  - The packet is of *OperationPacket* type
+- Expected postcondition
+  - The element x is enqueued to the local copy
+- Error condition
+  - If the precondition is violated
+
+## Correctness arguments
+
+### SCQ
+
+TODO
+
+### CCQ
+
+#### CCQ is **not** sequentially consistent
+
+First, we show why CCQ we presented is not sequentially consistent.
+Consider the following example:
+The parent blockchain issues enqueue(1), enqueue(2), enqueue(3) and read() = {1, 2, 3}.
+Moreover, the baby blockchain issues dequeue() = 1 and read() = {2}.
+
+Let us show that the aforementioned operations can indeed return the presented values.
+The parent blockchain issues the three enqueue operations and the read operation is invoked before the parent blockchain observes the dequeue() = 1 operation.
+Moreover, the baby blockchain issues the *dequeue() = 1* operation after it observes the enqueue(1) operation and it invokes the read() = 2 operation after it observes the enqueue(2) operation (and after it invokes dequeue() = 1), but before it observes enqueue(3).
+
+Lastly, we now explain why the following operations cannot be mapped into a valid sequential execution.
+Suppose that there exists a valid sequential execution *e*.
+We note that the following order must be respected in *e*:
+- *dequeue() = 1 -> read() = {2}*: Because *enqueue(1) -> enqueue(2)* and *read() = {2}*, we conclude that *dequeue() = 1 -> read() = {2}*.
+- *enqueue(3) -> read() = {1, 2, 3}*: Because *read() = {1, 2, 3}*, we conclude that this order must be satisfied.
+- *read() = {1, 2, 3} -> dequeue() = 1*: Because the read operation "contains" 1, we conclude that *read() = {1, 2, 3} -> dequeue(1)*.
+
+Given the previously defined order, we conclude that *enqueue(3) -> read() = {1, 2, 3} -> dequeue(1) -> read() = {2}* in *e*. 
+However, since *enqueue(3) -> read(2) = {2}* and there does not exist the *dequeue() = 3* operation, we conclude that the read operation invoked by the baby blockchain must "contain" 3.
+Hence, *e* is not valid.
+
+#### CCQ is causally consistent
+
+In order to show that CCQ is causally consistent, we need to show that both blockchains execute operations that are causally related in the correct and same order.
+
+In order to complete the proof, we need to incorporate the read operations.
+Recall that there is no communication between two blockchain in case of read operations.
+Hence, a blockchain does not really execute (nor observe) other blockchain's read operation.
+However, we do need to point out a moment in which the "abstract execution" takes place in order to prove the causal consistency of our implementation.
+
+A blockchain A executes its own read operation R at the moment returning from the operation.
+However, the other blockchain B executes this operation in moments as we define now:
+- Let R not be causally preceded by any write operation invoked by blockchain A.
+In this case, B executes R at the same moment as A.
+- Let R be preceded by a write operation W.
+In this case, B executes R immediately after it observes W.
+Note that if R is causally preceded by a read operation R' invoked by A which is also preceded by W, then R is executed by B immediately after R' is executed by B (note that R' is executed after W).
+
+Finally, we conclude the proof.
+Consider any two operations A and B such that A --> B.
+We show that both blockchains execute A before executing B.
+Let us investigate all cases:
+- A and B are invoked by the same blockchain:
+Trivially, the invoking blockchain does execute A before executing B.
+We now show that the other blockchain executes A before B:
+1) If both operations are write operations, then the fact that IBC channels are ordered ensures that the other blockchain executes A before B.
+2) If A is a write operation and B is a read operation, we conclude that B is executed at the other blockchain after the observation of the "first preceding" write operation W.
+Since W = A or A --> W, we conclude that A is indeed executed before B at the other blockchain.
+3) If A is a read operation and B is a write operation, we conclude that either A is executed at the same moment as it was executed in the invoking blockchain (which ensures that A is executed before B) or A is executed immediately after the observation of the "first preceding" write operation W (which ensures that A is executed before B since W --> B).
+4) If both operations are read operations, we conclude that it is impossible for B to be executed before A at the other blockchain.
+
+- A is a write operation and the blockchain that invokes B has observed A before invoking B:
+If A and B are invoked by the same blockchain, A is executed before B at both blockchains (see the previous case).
+Hence, we consider the case where A is invoked by blockchain C and B is invoked by blockchain D.
+Therefore, C executes A before B (since B is executed at the earliest at the same moment as D executes B, which is after executing A).
+Moreover, D executes A before B since it observes A before invoking B.
+
+- There exists an operation C such that A --> C and C --> B:
+Since this case eventually reduces to the previous two, we conclude that both blockchains execute A before B, which concludes the proof.
+
+## Generalization
+
+In this subsection, we generalize the approach presented above to multiple blockchains.
+
+### System model
+
+Consider a set of N blockchains such that every two blockchains are connected via an ordered IBC channel.
+Moreover, we assume that each blockchain can invoke all operations.
+
+### Modification of the approach given above
+
+Since now we have multiple blockchain, we introduce vector clocks in order to capture the causal precedence of write operations.
+A vector clock is simply an array of N elements (one per each blockchain) and it is associated with each write operation of each blockchain.
+For example, suppose that write operation A invoked by a blockchain B is associated with vector clock V.
+Let V[C] = x.
+This simply means that operation A is invoked **after** B had observed an x-th write operation issued by blockchain C.
+Hence, A operation is causally preceded by first x write operations issued by C.
+
+We compare vector clocks using the "<=" relation:
+For any two vector clocks V, V', V <= V' if and only if, for every index i, V[i] <= V'[i].
+
+Now we explain the modification in detail.
+Each blockchain maintains a local current vector clock V (initialized to all 0s).
+Once a blockchain issues an operation, it associates a vector clock W with the operation, such that W[self] is a sequence number of the write operation and W[i] = V[i], for every i != self.
+
+Lastly, once a blockchain receives an IBC packet about a write operation, it does not process this operation until W' <= V, where W' represents the vector clock associated with the received operation.
+Lastly, local vector clock is updated after each new operation is processed.
+Namely, once operation O issued by blockchain B is processed, the vector clock V is updated in the following manner: V[B] = V[B] + 1 and V[i] remains unchanged, for every i != B.

--- a/spec/client/ics-006-solo-machine-client/README.md
+++ b/spec/client/ics-006-solo-machine-client/README.md
@@ -186,6 +186,10 @@ function verifyClientState(
   clientIdentifier: Identifier,
   counterpartyClientState: ClientState) {
     path = applyPrefix(prefix, "clients/{clientIdentifier}/clientState")
+    // ICS 003 will not increment the proof height after connection verification
+    // the solo machine client must increment the proof height to ensure it matches 
+    // the expected sequence used in the signature
+    abortTransactionUnless(height + 1 == clientState.consensusState.sequence)
     abortTransactionUnless(!clientState.frozen)
     abortTransactionUnless(proof.timestamp >= clientState.consensusState.timestamp)
     value = clientState.consensusState.sequence + clientState.consensusState.diversifier + proof.timestamp + path + counterpartyClientState
@@ -203,6 +207,10 @@ function verifyClientConsensusState(
   consensusStateHeight: uint64,
   consensusState: ConsensusState) {
     path = applyPrefix(prefix, "clients/{clientIdentifier}/consensusState/{consensusStateHeight}")
+    // ICS 003 will not increment the proof height after connection or client state verification
+    // the solo machine client must increment the proof height by 2 to ensure it matches 
+    // the expected sequence used in the signature
+    abortTransactionUnless(height + 2 == clientState.consensusState.sequence)
     abortTransactionUnless(!clientState.frozen)
     abortTransactionUnless(proof.timestamp >= clientState.consensusState.timestamp)
     value = clientState.consensusState.sequence + clientState.consensusState.diversifier + proof.timestamp + path + consensusState
@@ -219,6 +227,7 @@ function verifyConnectionState(
   connectionIdentifier: Identifier,
   connectionEnd: ConnectionEnd) {
     path = applyPrefix(prefix, "connection/{connectionIdentifier}")
+    abortTransactionUnless(height == clientState.consensusState.sequence)
     abortTransactionUnless(!clientState.frozen)
     abortTransactionUnless(proof.timestamp >= clientState.consensusState.timestamp)
     value = clientState.consensusState.sequence + clientState.consensusState.diversifier + proof.timestamp + path + connectionEnd
@@ -236,6 +245,7 @@ function verifyChannelState(
   channelIdentifier: Identifier,
   channelEnd: ChannelEnd) {
     path = applyPrefix(prefix, "ports/{portIdentifier}/channels/{channelIdentifier}")
+    abortTransactionUnless(height == clientState.consensusState.sequence)
     abortTransactionUnless(!clientState.frozen)
     abortTransactionUnless(proof.timestamp >= clientState.consensusState.timestamp)
     value = clientState.consensusState.sequence + clientState.consensusState.diversifier + proof.timestamp + path + channelEnd
@@ -254,6 +264,7 @@ function verifyPacketData(
   sequence: uint64,
   data: bytes) {
     path = applyPrefix(prefix, "ports/{portIdentifier}/channels/{channelIdentifier}/packets/{sequence}")
+    abortTransactionUnless(height == clientState.consensusState.sequence)
     abortTransactionUnless(!clientState.frozen)
     abortTransactionUnless(proof.timestamp >= clientState.consensusState.timestamp)
     value = clientState.consensusState.sequence + clientState.consensusState.diversifier + proof.timestamp + path + data
@@ -272,6 +283,7 @@ function verifyPacketAcknowledgement(
   sequence: uint64,
   acknowledgement: bytes) {
     path = applyPrefix(prefix, "ports/{portIdentifier}/channels/{channelIdentifier}/acknowledgements/{sequence}")
+    abortTransactionUnless(height == clientState.consensusState.sequence)
     abortTransactionUnless(!clientState.frozen)
     abortTransactionUnless(proof.timestamp >= clientState.consensusState.timestamp)
     value = clientState.consensusState.sequence + clientState.consensusState.diversifier + proof.timestamp + path + acknowledgement
@@ -289,6 +301,7 @@ function verifyPacketReceiptAbsence(
   channelIdentifier: Identifier,
   sequence: uint64) {
     path = applyPrefix(prefix, "ports/{portIdentifier}/channels/{channelIdentifier}/receipts/{sequence}")
+    abortTransactionUnless(height == clientState.consensusState.sequence)
     abortTransactionUnless(!clientState.frozen)
     abortTransactionUnless(proof.timestamp >= clientState.consensusState.timestamp)
     value = clientState.consensusState.sequence + clientState.consensusState.diversifier + proof.timestamp + path
@@ -306,6 +319,7 @@ function verifyNextSequenceRecv(
   channelIdentifier: Identifier,
   nextSequenceRecv: uint64) {
     path = applyPrefix(prefix, "ports/{portIdentifier}/channels/{channelIdentifier}/nextSequenceRecv")
+    abortTransactionUnless(height == clientState.consensusState.sequence)
     abortTransactionUnless(!clientState.frozen)
     abortTransactionUnless(proof.timestamp >= clientState.consensusState.timestamp)
     value = clientState.consensusState.sequence + clientState.consensusState.diversifier + proof.timestamp + path + nextSequenceRecv


### PR DESCRIPTION
This is a draft for the specification for cross-chain validator set update by @jovankomatovic. It currently consists of two modules

- a shared queue (causally consistent)
- a module that uses the shared queue to maintain the validator sets

This PR is for discussion. 

The plan so to replace the queue by a new sliding window module where one chains calls `add` to append an item at the top of the list, and the other chain calls `ack` to acknowledge an item.