### PR TITLE
Fix Interchain Account bug allowing controller account to use host port

### DIFF
--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -269,7 +269,7 @@ function onChanOpenInit(
   abortTransactionUnless(version === "ics27-1")
   // Only open the channel if there is no active channel already set (with status OPEN)
   abortTransactionUnless(activeChannel === nil)
-  }
+}
 ```
 
 ```typescript

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -261,13 +261,15 @@ function onChanOpenInit(
   version: string) {
   // only ordered channels allowed
   abortTransactionUnless(order === ORDERED)
+  // Host chain port address cannot be used for a controller account
+  abortTransactionUnless(portIdentifier !== "interchain-account")
   // only allow channels to "interchain_account" port on counterparty chain
   abortTransactionUnless(counterpartyPortIdentifier === "interchain-account")
   // version not used at present
   abortTransactionUnless(version === "ics27-1")
   // Only open the channel if there is no active channel already set (with status OPEN)
   abortTransactionUnless(activeChannel === nil)
-}
+  }
 ```
 
 ```typescript


### PR DESCRIPTION
While implementing the interchain accounts spec, we realized there was no check preventing a controller account from [accidentally](https://github.com/cosmos/ibc-go/pull/355#discussion_r697471820) using the port representing the chain as a host chain

I believe this check is necessary in preventing a chain from allowing the port reserved for host chain actions, to be used 