### PR TITLE
ICS 026: modify onChanOpenAck interface to take in counterpartyChannelIdentifier

### DIFF
--- a/spec/app/ics-020-fungible-token-transfer/README.md
+++ b/spec/app/ics-020-fungible-token-transfer/README.md
@@ -159,10 +159,11 @@ function onChanOpenTry(
 function onChanOpenAck(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
-  version: string) {
+  counterpartyChannelIdentifier: Identifier,
+  counterpartyVersion: string) {
   // port has already been validated
-  // assert that version is "ics20-1"
-  abortTransactionUnless(version === "ics20-1")
+  // assert that counterparty selected version is "ics20-1"
+  abortTransactionUnless(counterpartyVersion === "ics20-1")
 }
 ```
 

--- a/spec/app/ics-027-interchain-accounts/README.md
+++ b/spec/app/ics-027-interchain-accounts/README.md
@@ -422,6 +422,7 @@ function onChanOpenTry(
 function onChanOpenAck(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
+  counterpartyChannelIdentifier,
   counterpartyVersion: string) {
 
   // validate counterparty metadata decided by host chain

--- a/spec/app/ics-029-fee-payment/README.md
+++ b/spec/app/ics-029-fee-payment/README.md
@@ -255,8 +255,9 @@ function OnChanOpenTry(
 function onChanOpenAck(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
-  version: string) {
-      feeVersion, appVersion = splitFeeVersion(version)
+  counterpartyChannelIdentifier: Identifier,
+  counterpartyVersion: string) {
+      feeVersion, appVersion = splitFeeVersion(counterpartyVersion)
       if !isSupported(feeVersion) {
           return error
       }

--- a/spec/app/ics-030-middleware/README.md
+++ b/spec/app/ics-030-middleware/README.md
@@ -129,8 +129,9 @@ function OnChanOpenTry(
 function onChanOpenAck(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
-  version: string) {
-      middlewareVersion, appVersion = splitMiddlewareVersion(version)
+  counterpartyChannelIdentifier: Identifier,
+  counterpartyVersion: string) {
+      middlewareVersion, appVersion = splitMiddlewareVersion(counterpartyVersion)
       if !isCompatible(middlewareVersion) {
           return error
       }

--- a/spec/core/ics-026-routing-module/README.md
+++ b/spec/core/ics-026-routing-module/README.md
@@ -102,7 +102,8 @@ is invalid to abort the handshake. It may also perform custom ACK logic.
 function onChanOpenAck(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
-  version: string) {
+  counterpartyChannelIdentifier: Identifier, 
+  counterpartyVersion: string) {
     // defined by the module
 }
 ```
@@ -504,7 +505,8 @@ function handleChanOpenAck(datagram: ChanOpenAck) {
     err = module.onChanOpenAck(
       datagram.portIdentifier,
       datagram.channelIdentifier,
-      datagram.version
+      datagram.counterpartyChannelIdentifier,
+      datagram.counterpartyVersion
     )
     abortTransactionUnless(err === nil)
     handler.chanOpenAck(


### PR DESCRIPTION
Changes to onChanOpenAck:
- rename version to counterpartyVersion
- add counterpartyChannelIdentifier argument

closes #674