### PR TITLE
Add ChanUpgradeCancelConfirm datagram and handler to reset upgrade state

### DIFF
--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -505,10 +505,14 @@ function chanUpgradeConfirm(
 
 **Protocol**:
 
-During the upgrade handshake an aborting chain may cancel the upgrade by writing an error receipt into the error path and restoring the original channel to `OPEN`. The counterparty must then restore its channel to `OPEN` as well. A relayer can facilitate this by sending `ChanUpgradeCancelInitMsg` to the counterparty chain's handler:
+During the upgrade handshake an aborting chain may cancel the upgrade by writing an error receipt into the error path and restoring the original channel to `OPEN`. The counterparty must then restore its original channel to `OPEN` as well.
+
+A channelEnd may only cancel the upgrade during the upgrade negotiation process (`TRY`, `ACK`). Thus, the counterparty channel state must be either `UPGRADE_INIT` or `UPGRADE_TRY`. An upgrade cannot be cancelled on one end once the other chain has already completed its upgrade and moved to `OPEN` since that will lead the channel to being in an invalid state.
+
+Once the aborting chain has written to the error receipt, a relayer must submit `ChanUpgradeCancelInit` to the counterparty chain:
 
 ```typescript
-function cancelChannelUpgradeInit(
+function chanUpgradeCancelInit(
     portIdentifier: Identifier,
     channelIdentifier: Identifier,
     errorReceipt: []byte,

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -570,7 +570,7 @@ function chanUpgradeCancelConfirm(
     abortTransactionUnless(verifyChannelState(connection, height, proof, portIdentifier, channelIdentifier, counterpartyChannel))
 
     // delete error receipt so that new upgrades can proceed
-    provableStore.delete(errorPath)
+    provableStore.delete(errorPath(portIdentifier, channelIdentifier))
 }
 ```
 

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -82,7 +82,7 @@ interface ErrorReceipt {
 }
 ```
 
-- `counterpartyHeight`: Counterparty height is the proof height of the counterparty when the executing chain aborts the upgrade process. This height will get used to clear the error receipt before future upgrades.
+- `counterpartyHeight`: Counterparty height is the proof height of the counterparty when the executing chain aborts the upgrade process. This height will get used to verify that the error receipt submitted on `ChanUpgradeCancel` is for the current upgrade and not a stale error receipt.
 - `errorMsg`: Error Msg is an arbitrary string that chains may use to provide more information as to why the upgrade failed.
 
 ### Store Paths

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -499,6 +499,12 @@ function chanUpgradeConfirm(
 
 ### Cancel Upgrade Process
 
+**Sub-Definitions**:
+
+`Aborting Chain`: This is the chain that first encounters an error, writes data to the error receipt and restores the connection.
+
+**Protocol**:
+
 During the upgrade handshake an aborting chain may cancel the upgrade by writing an error receipt into the error path and restoring the original channel to `OPEN`. The counterparty must then restore its channel to `OPEN` as well. A relayer can facilitate this by sending `ChanUpgradeCancelInitMsg` to the counterparty chain's handler:
 
 ```typescript
@@ -540,7 +546,7 @@ function cancelChannelUpgradeInit(
 }
 ```
 
-Once the counterparty has aborted the handshake and cleared all upgrade state, the aborting chain will also need to clear its remaining upgrade state (error receipt) in order to ensure that this stale upgrade state does not interfere with future upgrades. To do this a relayer can send a `ChanUpgradeCancelConfirmMsg` to the handler on the original aborting chain's handler:
+Once the counterparty has also aborted the handshake and cleared all upgrade state, the aborting chain will also need to clear its remaining upgrade state (error receipt) in order to ensure that this stale upgrade state does not interfere with future upgrades. To do this a relayer can send a `ChanUpgradeCancelConfirmMsg` to the handler on the original aborting chain's handler:
 
 ```typescript
 function chanUpgradeCancelConfirm(

--- a/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/UPGRADES.md
@@ -501,7 +501,7 @@ function chanUpgradeConfirm(
 
 **Sub-Definitions**:
 
-`Aborting Chain`: This is the chain that first encounters an error, writes data to the error receipt and restores the connection.
+`Aborting Chain`: This is the chain that first encounters an error, writes data to the error receipt and restores the channel.
 
 **Protocol**:
 


### PR DESCRIPTION
Closes: #698 for channels

We clear the error receipt by sending a message back to the original aborting chain that proves that the counterparty has restored their channel