### PR TITLE
Add packet handling logic to multihop

### DIFF
--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -333,6 +333,8 @@ function chanOpenTry(
     abortTransactionUnless(connection.state === OPEN)
     expected = ChannelEnd{INIT, order, portIdentifier,
                           "", [connection.counterpartyConnectionIdentifier], counterpartyVersion}
+    // handshake messages must be proven against
+    // every possible route
     for i = 0; i < len(connectionHops); i++ {
       // prove channel state on each connection route
       connection = getConnection(connectionHops[i])

--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -333,6 +333,8 @@ function chanOpenInit(
 The `chanOpenTry` function is called by a module to accept the first step of a channel opening handshake initiated by a module on another chain.
 
 ```typescript
+// the connectionHops in TRY must be the same routes as the ones set in INIT in the same order
+// the connectionIDs will represent the identifiers in the other direction from the TRY chain to the ACK chain.
 function chanOpenTry(
   order: ChannelOrder,
   connectionHops: [Identifier],
@@ -340,39 +342,58 @@ function chanOpenTry(
   counterpartyPortIdentifier: Identifier,
   counterpartyChannelIdentifier: Identifier,
   version: string, // deprecated
-  counterpartyVersion: string,
-  proofInit: CommitmentProof,
-  proofHeight: Height): CapabilityKey {
+  initChannel: ChannelEnd,
+  proofInit: [CommitmentProof],
+  proofHeight: [Height]): CapabilityKey {
     channelIdentifier = generateIdentifier()
 
     abortTransactionUnless(validateChannelIdentifier(portIdentifier, channelIdentifier))
     abortTransactionUnless(authenticateCapability(portPath(portIdentifier), portCapability))
-    connection = provableStore.get(connectionPath(connectionHops[0]))
 
-    expected = ChannelEnd{INIT, order, portIdentifier,
-                          "", [connection.counterpartyConnectionIdentifier], counterpartyVersion}
+    abortTransactionUnless(initChannel.state == INIT)
+    abortTransactionUnless(initChannel.order == order)
+    abortTransactionUnless(initChannel.counterpartyPortIdentifier == portIdentifier)
     
     // handshake messages must be proven against
     // every possible route
     for i := 0; i < len(connectionHops); i++ {
       route = connectionHops[i]
-      nextHopConnectionId = getNextHop(route)
+
+      hops = splitRoute(route)
+
+      nextHopConnectionId = getNextHop(hops[0])
       connection = provableStore.get(connectionPath(nextHopConnectionId))
 
       abortTransactionUnless(connection !== null)
       abortTransactionUnless(connection.state === OPEN)
 
-      abortTransactionUnless(connection.verifyChannelState(
-        proofHeight,
-        proofInit,
-        counterpartyPortIdentifier,
-        counterpartyChannelIdentifier,
-        expected
-      ))
+      client = queryClient(connection.clientIdentifier)
+      value = protobuf.marshal(initChannel)
+
+      if len(hops == 1) {
+        abortTransactionUnless(connection.verifyChannelState(
+          proofHeight[i],
+          proofInit[i],
+          counterpartyPortIdentifier,
+          counterpartyChannelIdentifier,
+          initChannel
+        ))
+      } else {
+        counterpartyHops = splitRoute(initChannel.connectionHops[i])
+
+        // we prove that the last hop from the initChannel for this route is the counterparty for the first hop of our route
+        abortTransactionUnless(connection.counterpartyConnectionIdentifier == counterpartyHops[len(counterpartyHops)-1])
+
+        // we then prove that the next connection in this route stored
+        // the initChannel under the full connectionHops stored on initChannel
+        path = append(initChannel.connectionHops[i], channelPath(counterpartyPortIdentifier, counterpartyChannelIdentifier))
+
+        verifyMembership(client, proofHeight[i], 0, 0, proofInit[i], path, value)
+      }
     }
     
-    channel = ChannelEnd{TRYOPEN, order, counterpartyPortIdentifier,
-                         counterpartyChannelIdentifier, connectionHops, version}
+    channel = ChannelEnd{TRYOPEN, order, initChannel.portIdentifier,
+                         initChannel.channelIdentifier, connectionHops, version}
     provableStore.set(channelPath(portIdentifier, channelIdentifier), channel)
     channelCapability = newCapability(channelCapabilityPath(portIdentifier, channelIdentifier))
 
@@ -393,33 +414,54 @@ function chanOpenAck(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
   counterpartyChannelIdentifier: Identifier,
-  counterpartyVersion: string,
-  proofTry: CommitmentProof,
-  proofHeight: Height) {
+  tryChannel: ChannelEnd,
+  proofTry: [CommitmentProof],
+  proofHeight: [Height]) {
     channel = provableStore.get(channelPath(portIdentifier, channelIdentifier))
     abortTransactionUnless(channel.state === INIT || channel.state === TRYOPEN)
     abortTransactionUnless(authenticateCapability(channelCapabilityPath(portIdentifier, channelIdentifier), capability))
    
-    expected = ChannelEnd{TRYOPEN, channel.order, portIdentifier,
-                          channelIdentifier, [connection.counterpartyConnectionIdentifier], counterpartyVersion}
+    abortTransactionUnless(tryChannel.state == TRYOPEN)
+    abortTransactionUnless(tryChannel.order == channel.order)
+    abortTransactionUnless(tryChannel.counterpartyPortIdentifier == portIdentifier)
+    abortTransactionUnless(tryChannel.counterpartyChannelIdentifier == channelIdentifier)
 
     // handshake messages must be proven against
     // every possible route
-    for i = 0; i < len(connectionHops); i++ {
+    for i := 0; i < len(connectionHops); i++ {
       route = connectionHops[i]
-      nextHopConnectionId = getNextHop(route)
+
+      hops = splitRoute(route)
+
+      nextHopConnectionId = getNextHop(hops[0])
       connection = provableStore.get(connectionPath(nextHopConnectionId))
 
       abortTransactionUnless(connection !== null)
       abortTransactionUnless(connection.state === OPEN)
 
-      abortTransactionUnless(connection.verifyChannelState(
-        proofHeight,
-        proofTry,
-        channel.counterpartyPortIdentifier,
-        counterpartyChannelIdentifier,
-        expected
-      ))
+      client = queryClient(connection.clientIdentifier)
+      value = protobuf.marshal(tryChannel)
+
+      if len(hops == 1) {
+        abortTransactionUnless(connection.verifyChannelState(
+          proofHeight[i],
+          proofTry[i],
+          channel.counterpartyPortIdentifier,
+          channel.counterpartyChannelIdentifier,
+          tryChannel
+        ))
+      } else {
+        counterpartyHops = splitRoute(tryChannel.connectionHops[i])
+
+        // we prove that the last hop from the tryChannel for this route is the counterparty for the first hop of our route
+        abortTransactionUnless(connection.counterpartyConnectionIdentifier == counterpartyHops[len(counterpartyHops)-1])
+
+        // we then prove that the next connection in this route stored
+        // the tryChannel under the full connectionHops stored on tryChannel
+        path = append(try.connectionHops[i], channelPath(channel.counterpartyPortIdentifier, channel.counterpartyChannelIdentifier))
+
+        verifyMembership(client, proofHeight[i], 0, 0, proofTry[i], path, value)
+      }
     }
     
     channel.state = OPEN
@@ -436,33 +478,55 @@ of the handshake-originating module on the other chain and finish the channel op
 function chanOpenConfirm(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
-  proofAck: CommitmentProof,
-  proofHeight: Height) {
+  ackChannel: ChannelEnd,
+  proofAck: [CommitmentProof],
+  proofHeight: [Height]) {
     channel = provableStore.get(channelPath(portIdentifier, channelIdentifier))
     abortTransactionUnless(channel !== null)
     abortTransactionUnless(channel.state === TRYOPEN)
     abortTransactionUnless(authenticateCapability(channelCapabilityPath(portIdentifier, channelIdentifier), capability))
     
-    expected = ChannelEnd{OPEN, channel.order, portIdentifier,
-                          channelIdentifier, [connection.counterpartyConnectionIdentifier], channel.version}
+    abortTransactionUnless(ackChannel.state == OPEN)
+    abortTransactionUnless(ackChannel.order == order)
+    abortTransactionUnless(ackChannel.counterpartyPortIdentifier == portIdentifier)
+    abortTransactionUnless(ackChannel.counterpartyChannelIdentifier == channelIdentifier)
 
     // handshake messages must be proven against
     // every possible route
-    for i = 0; i < len(connectionHops); i++ {
+    for i := 0; i < len(connectionHops); i++ {
       route = connectionHops[i]
-      nextHopConnectionId = getNextHop(route)
+
+      hops = splitRoute(route)
+
+      nextHopConnectionId = getNextHop(hops[0])
       connection = provableStore.get(connectionPath(nextHopConnectionId))
 
       abortTransactionUnless(connection !== null)
       abortTransactionUnless(connection.state === OPEN)
 
-      abortTransactionUnless(connection.verifyChannelState(
-        proofHeight,
-        proofAck,
-        channel.counterpartyPortIdentifier,
-        channel.counterpartyChannelIdentifier,
-        expected
-      ))
+      client = queryClient(connection.clientIdentifier)
+      value = protobuf.marshal(ackChannel)
+
+      if len(hops == 1) {
+        abortTransactionUnless(connection.verifyChannelState(
+          proofHeight[i],
+          proofAck[i],
+          channel.counterpartyPortIdentifier,
+          channel.counterpartyChannelIdentifier,
+          ackChannel
+        ))
+      } else {
+        counterpartyHops = splitRoute(ackChannel.connectionHops[i])
+
+        // we prove that the last hop from the tryChannel for this route is the counterparty for the first hop of our route
+        abortTransactionUnless(connection.counterpartyConnectionIdentifier == counterpartyHops[len(counterpartyHops)-1])
+
+        // we then prove that the next connection in this route stored
+        // the tryChannel under the full connectionHops stored on tryChannel
+        path = append(ackChannel.connectionHops[i], channelPath(channel.counterpartyPortIdentifier, channel.counterpartyChannelIdentifier))
+
+        verifyMembership(client, proofHeight[i], 0, 0, proofAck[i], path, value)
+      }
     }
 
     channel.state = OPEN

--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -311,8 +311,8 @@ function chanOpenInit(
     // optimistic channel handshakes are allowed
     // so next connection does not need to be OPEN but it does need to exist for each proposed route
     for i := 0; i < len(connectionHops); i++ {
-      route = connectionHops[i]
-      nextHopConnectionId = getNextHop(route)
+      hops = splitRoute(connectionHops[i])
+      nextHopConnectionId = hops[0]
       connection = provableStore.get(connectionPath(nextHopConnectionId))
 
       abortTransactionUnless(connection !== null)
@@ -357,9 +357,7 @@ function chanOpenTry(
     // handshake messages must be proven against
     // every possible route
     for i := 0; i < len(connectionHops); i++ {
-      route = connectionHops[i]
-
-      hops = splitRoute(route)
+      hops = splitRoute(connectionHops[i])
 
       nextHopConnectionId = getNextHop(hops[0])
       connection = provableStore.get(connectionPath(nextHopConnectionId))
@@ -429,9 +427,7 @@ function chanOpenAck(
     // handshake messages must be proven against
     // every possible route
     for i := 0; i < len(connectionHops); i++ {
-      route = connectionHops[i]
-
-      hops = splitRoute(route)
+      hops = splitRoute(connectionHops[i])
 
       nextHopConnectionId = getNextHop(hops[0])
       connection = provableStore.get(connectionPath(nextHopConnectionId))
@@ -494,9 +490,7 @@ function chanOpenConfirm(
     // handshake messages must be proven against
     // every possible route
     for i := 0; i < len(connectionHops); i++ {
-      route = connectionHops[i]
-
-      hops = splitRoute(route)
+      hops = splitRoute(connectionHops[i])
 
       nextHopConnectionId = getNextHop(hops[0])
       connection = provableStore.get(connectionPath(nextHopConnectionId))

--- a/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
@@ -26,6 +26,24 @@ function routeInfoPath(connectionId: Identifier, route: Identifier, portIdentifi
 }
 ```
 
+### Data Structures
+
+In order to implement the Router specification for ICS-4, the chain must store the following `routeInfo` data under the `routeInfoPath`
+
+```typescript
+interface RouteInfo {
+    // this is a list of the continued routes from the current chain to the destination chain
+    // since there may be multiple routes for a given channel that includes the same chain,
+    // this may be a list of Identifiers.
+    // Each Identifier is a route (ie a joined list of connection identifiers by `/`)
+    destHops: [Identifier],
+    // the provingConnectionIdentifier is the connection Identifier that exists on the executing chain
+    // It must be used to prove any information coming from the sourceHops (stored in the RouteInfo path)
+    // The provingConnectionIdentifier must be the counterparty identifier of the last hop on the sourceHops
+    provingConnectionIdentifier: Identifier,
+}
+```
+
 ### Channel Handshake
 
 ```typescript

--- a/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
@@ -1,0 +1,53 @@
+# Router Specification
+
+### Synopsis
+
+The following document specifies the interfaces and state machine logic that IBC implementations must implement if they wish to serve as a Router chain.
+
+### Motivation
+
+// TODO
+
+### Desired Properties
+
+// TODO
+
+## Technical Specification
+
+### Data Structures
+
+### Store Paths
+
+### Channel Handshake
+
+```typescript
+function routeChanOpenTry(
+    order: ChannelOrder,
+    sourceConnectionHops: [Identifier],
+    destConnectionHops: [Identifier],
+    counterpartyPortIdentifier: Identifier,
+    counterpartyChannelIdentifier: Identifier,
+    proofInit: CommitmentProof,
+    proofHeight: Height
+) {
+    if len(sourceConnectionHops) == 0 {
+        return
+    }
+    connection = getConnection(sourceConnectionHops[len(sourceConnectionHops)-1])
+    if sourceConnectionHops > 1 {
+        // prove that previous hop stored channel under channel path and prefixed by sourceConnectionHops[1:]
+    } else {
+        // prove that previous hop (original source) stored channel under channel path
+    }
+    connectionHops = append(sourceConnectionHops, destConnectionHops...)
+    // store channel under channelPath prefixed by sourceConnectionHops
+
+    // store source identifiers -> sourceConnectionHops
+    store(counterpartyPortIdentifier, counterpartyChannelIdentifier, sourceConnectionHops)
+}
+
+// similar logic for other handshake methods
+```
+
+
+

--- a/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
@@ -107,7 +107,6 @@ function routeChanOpenTry(
     provableStore.set(routeChannelPath(append(srcConnectionHops), portIdentifier, channelIdentifier), initChannel)    
 
 }
-
 ```
 
 ```typescript
@@ -133,9 +132,9 @@ function routeChanOpenAck(
     route = join(append(srcConnectionHops, destConnectionHops...), "/")
     abortTransactionUnless(route in tryChannel.connectionHops)
 
-    abortTransactionUnless(initChannel.state == TRYOPEN)
-    abortTransactionUnless(initChannel.counterpartyPortIdentifier == portIdentifier)
-    abortTransactionUnless(initChannel.counterpartyChannelIdentifier == channelIdentifier)
+    abortTransactionUnless(tryChannel.state == TRYOPEN)
+    abortTransactionUnless(tryChannel.counterpartyPortIdentifier == portIdentifier)
+    abortTransactionUnless(tryChannel.counterpartyChannelIdentifier == channelIdentifier)
 
     abortTransactionUnless(provableStore.get(routeChannelPath(append(srcConnectionHops), portIdentifier, channelIdentifier)) !== null)
 
@@ -181,9 +180,9 @@ function routeChanOpenConfirm(
     route = join(append(srcConnectionHops, destConnectionHops...), "/")
     abortTransactionUnless(route in ackChannel.connectionHops)
 
-    abortTransactionUnless(initChannel.state == TRYOPEN)
-    abortTransactionUnless(initChannel.counterpartyPortIdentifier == portIdentifier)
-    abortTransactionUnless(initChannel.counterpartyChannelIdentifier == channelIdentifier)
+    abortTransactionUnless(ackChannel.state == TRYOPEN)
+    abortTransactionUnless(ackChannel.counterpartyPortIdentifier == portIdentifier)
+    abortTransactionUnless(ackChannel.counterpartyChannelIdentifier == channelIdentifier)
 
     connection = getConnection(provingConnectionIdentifier)
     abortTransactionUnless(connection !== null)
@@ -225,6 +224,8 @@ function routePacket(
     // retrieve channel state.
     // this retrieves either the TryChannel or the AckChannel, depending which chain sends the packet
     // this depends on srcConncetionHops
+    // we use packet.destPort, packet.destChannel because the channel state is stored under the counterparties
+    // port and channel
     channel = provableStore.get(append(srcConnectionHops, channelPath(packet.destPort, packet.destChannel)))
     abortTransactionUnless(channel !== null)
     abortTransactionUnless(channel.state !== CLOSED)
@@ -284,6 +285,8 @@ function routeAcknowledgmentPacket(
 
     // retrieve channel state. This will retrieve either the TryChannel or the AckChannel, depending which chain sends the packet
     // this depends on srcConncetionHops
+    // we use packet.sourcePort, packet.sourceChannel because the relevant channel state is stored under the counterparties
+    // port and channel of the packet's sender
     channel = provableStore.get(append(srcConnectionHops, channelPath(packet.sourcePort, packet.sourceChannel)))
     abortTransactionUnless(channel !== null)
     abortTransactionUnless(channel.state !== CLOSED)

--- a/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
@@ -86,10 +86,6 @@ function routeChanOpenTry(
         // prove that previous hop (original source) stored channel under channel path
         verifyChannelState(connection, proofHeight, proofInit, counterpartyPortIdentifier, counterpartyChannelIdentifier, initChannel)
     }
-
-    // store channel under channelPath prefixed by srcConnectionHops
-    path = append(srcConnectionHops, channelPath(counterpartyPortIdentifier, counterpartyChannelIdentifier))
-    store.set(path, initChannel)
 }
 
 // srcConnectionHops is the connection Hops from the TRY chain to the executing router chain

--- a/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
@@ -106,10 +106,141 @@ function routeChanOpenAck(
 ```typescript
 // if path is prefixed by portId and channelId and it is stored by last
 // connection in srcConnectionHops then store under same path prefixed by srcConnectionHops
-function routeChannelData(
-    sourceHops: [Identifier],
-    portIdentifier: Identifier,
-    channelIdentifier: Identifier,
-    path: CommitmentPath
-)
+function routePacket(
+    packet: OpaquePacket,
+    proof: CommitmentProof,
+    proofHeight: Height,
+    sourceConnectionHops: [Identifier], //ordered from source up to self. It starts from 0.
+    destConnectionHops: [Identifier] //ordered from dest up to self. It starts from 0.
+) {
+    previousHopConnectionId = sourceConnectionHops[len(sourceConnectionHops)-1]
+    connection = getConnection(previousHopConnectionId)
+    if len(sourceConnectionHops) > 1 {
+        clientState = queryClient(connection.clientIdentifier)
+        prefix = sourceConnectionHops[0:len(sourceConnectionHops)-2]
+        abortTransactionUnless(verifyMembership(clientState,
+                                                proofHeight,
+                                                0,
+                                                0,
+                                                proof,
+                                                routePacketPath(prefix, packet.sourcePort, packet.sourceChannel, packet.sequence),
+                                                hash(packet.data, packet.timeoutHeight, packet.timeoutTimestamp)))
+    } else {
+        abortTransactionUnless(connection.verifyPacketData(proofHeight,
+                                                           proof,
+                                                           packet.sourcePort,
+                                                           packet.sourceChannel,
+                                                           packet.sequence,
+                                                           concat(packet.data,
+                                                                  packet.timeoutHeight,
+                                                                  packet.timeoutTimestamp)))
+    }
+
+    path = routePacketPath(sourceConnectionHops, packet.sourcePort, packet.sourceChannel, packet.sequence)
+    provableStore.set(path, hash(packet.data, packet.timeoutHeight, packet.timeoutTimestamp))
+
+    if len(destConnectionHops) > 1{
+        emitLogEntry("routePacket", {sequence: packet.sequence, data: packet.data, timeoutHeight: packet.timeoutHeight, timeoutTimestamp: packet.timeoutTimestamp})
+    } else{
+        emitLogEntry("sendPacket", {sequence: packet.sequence, data: packet.data, timeoutHeight: packet.timeoutHeight, timeoutTimestamp: packet.timeoutTimestamp})
+    }
+}
+```
+
+```typescript
+function routeAcknowledgmentPacket(
+    packet: OpaquePacket,
+    acknowledgement: bytes,
+    proof: CommitmentProof,
+    proofHeight: Height,
+    sourceConnectionHops: [Identifier], //ordered from source up to self. It starts from 0.
+    destConnectionHops: [Identifier] //ordered from dest up to self. It starts from 0.
+) {
+    previousHopConnectionId = sourceConnectionHops[len(sourceConnectionHops)-1]
+    connection = getConnection(previousHopConnectionId)
+    if len(sourceConnectionHops) > 1 {
+        clientState = queryClient(connection.clientIdentifier)
+        prefix = sourceConnectionHops[0:len(sourceConnectionHops)-2]
+        abortTransactionUnless(verifyMembership(clientState,
+                                                proofHeight,
+                                                0,
+                                                0,
+                                                proof,
+                                                routeAckPath(prefix, packet.destPort, packet.destChannel, packet.sequence),
+                                                hash(acknowledgement)))
+    } else {
+        abortTransactionUnless(connection.verifyPacketAcknowledgement(proofHeight,
+                                                                      proof,
+                                                                      packet.destPort,
+                                                                      packet.destChannel,
+                                                                      packet.sequence,
+                                                                      acknowledgement))
+    }
+
+    path = routeAckPath(sourceConnectionHops, packet.destPort, packet.destChannel, packet.sequence)
+    provableStore.set(path, hash(acknowledgement))
+
+    if len(destConnectionHops) > 1{
+        emitLogEntry("routeAcknowledgement", {sequence: packet.sequence, timeoutHeight: packet.timeoutHeight, port: packet.destPort,channel: packet.destChannel, timeoutTimestamp: packet.timeoutTimestamp, data: packet.data, acknowledgement})
+    } else{
+        emitLogEntry("writeAcknowledgement", {sequence: packet.sequence, timeoutHeight: packet.timeoutHeight, port: packet.destPort,channel: packet.destChannel, timeoutTimestamp: packet.timeoutTimestamp, data: packet.data, acknowledgement})
+    }
+}
+```
+
+```typescript
+function routeTimeoutPacket(
+    packet: OpaquePacket,
+    acknowledgement: bytes,
+    proof: CommitmentProof,
+    proofHeight: Height,
+    nextSequenceRecv: uint64,
+    sourceConnectionHops: [Identifier], //ordered from source up to self. It starts from 0.
+    destConnectionHops: [Identifier] //ordered from dest up to self. It starts from 0.
+) {
+
+    channel = provableStore.get(append(sourceConnectionHops ,channelPath(packet.sourcePort, packet.sourceChannel)))
+    abortTransactionUnless(channel !== null)
+    abortTransactionUnless(channel.state === OPEN)
+
+    previousHopConnectionId = sourceConnectionHops[len(sourceConnectionHops)-1]
+    connection = getConnection(previousHopConnectionId)
+    if len(sourceConnectionHops) > 1 {
+        clientState = queryClient(connection.clientIdentifier)
+        prefix = sourceConnectionHops[0:len(sourceConnectionHops)-2]
+        abortTransactionUnless(verifyMembership(clientState,
+                                                proofHeight,
+                                                0,
+                                                0,
+                                                proof,
+                                                routeTimeoutPath(prefix, packet.destPort, packet.destChannel, packet.sequence),
+                                                1))
+    } else {
+        abortTransactionUnless((packet.timeoutHeight > 0 && proofHeight >= packet.timeoutHeight) ||
+                               (packet.timeoutTimestamp > 0 && connection.getTimestampAtHeight(proofHeight) > packet.timeoutTimestamp))
+        if channel.order === ORDERED {
+            // ordered channel: check that packet has not been received
+            abortTransactionUnless(nextSequenceRecv <= packet.sequence)
+            // ordered channel: check that the recv sequence is as claimed
+            abortTransactionUnless(connection.verifyNextSequenceRecv(proofHeight,
+                                                                     proof,
+                                                                     packet.destPort,
+                                                                     packet.destChannel,
+                                                                     nextSequenceRecv))
+        } else {
+            // unordered channel: verify absence of receipt at packet index
+            abortTransactionUnless(connection.verifyPacketReceiptAbsence(proofHeight,
+                                                                         proof,
+                                                                         packet.destPort,
+                                                                         packet.destChannel,
+                                                                         packet.sequence))
+        }
+    }
+
+    path = routeTimeoutPath(sourceConnectionHops, packet.destPort, packet.destChannel, packet.sequence)
+    provableStore.set(path, 1)
+
+    emitLogEntry("routeTimeout", {sequence: packet.sequence, timeoutHeight: packet.timeoutHeight, port: packet.destPort,channel: packet.destChannel, timeoutTimestamp: packet.timeoutTimestamp, data: packet.data})
+}
+```
 

--- a/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
@@ -111,7 +111,6 @@ function routePacket(
     proof: CommitmentProof,
     proofHeight: Height,
     sourceConnectionHops: [Identifier], //ordered from source up to self. It starts from 0.
-    destConnectionHops: [Identifier] //ordered from dest up to self. It starts from 0.
 ) {
     previousHopConnectionId = sourceConnectionHops[len(sourceConnectionHops)-1]
     connection = getConnection(previousHopConnectionId)
@@ -139,11 +138,7 @@ function routePacket(
     path = routePacketPath(sourceConnectionHops, packet.sourcePort, packet.sourceChannel, packet.sequence)
     provableStore.set(path, hash(packet.data, packet.timeoutHeight, packet.timeoutTimestamp))
 
-    if len(destConnectionHops) > 1{
-        emitLogEntry("routePacket", {sequence: packet.sequence, data: packet.data, timeoutHeight: packet.timeoutHeight, timeoutTimestamp: packet.timeoutTimestamp})
-    } else{
-        emitLogEntry("sendPacket", {sequence: packet.sequence, data: packet.data, timeoutHeight: packet.timeoutHeight, timeoutTimestamp: packet.timeoutTimestamp})
-    }
+    emitLogEntry("routePacket", {sequence: packet.sequence, data: packet.data, timeoutHeight: packet.timeoutHeight, timeoutTimestamp: packet.timeoutTimestamp})
 }
 ```
 
@@ -180,11 +175,7 @@ function routeAcknowledgmentPacket(
     path = routeAckPath(sourceConnectionHops, packet.destPort, packet.destChannel, packet.sequence)
     provableStore.set(path, hash(acknowledgement))
 
-    if len(destConnectionHops) > 1{
-        emitLogEntry("routeAcknowledgement", {sequence: packet.sequence, timeoutHeight: packet.timeoutHeight, port: packet.destPort,channel: packet.destChannel, timeoutTimestamp: packet.timeoutTimestamp, data: packet.data, acknowledgement})
-    } else{
-        emitLogEntry("writeAcknowledgement", {sequence: packet.sequence, timeoutHeight: packet.timeoutHeight, port: packet.destPort,channel: packet.destChannel, timeoutTimestamp: packet.timeoutTimestamp, data: packet.data, acknowledgement})
-    }
+    emitLogEntry("routeAcknowledgement", {sequence: packet.sequence, timeoutHeight: packet.timeoutHeight, port: packet.destPort,channel: packet.destChannel, timeoutTimestamp: packet.timeoutTimestamp, data: packet.data, acknowledgement})
 }
 ```
 
@@ -199,7 +190,7 @@ function routeTimeoutPacket(
     destConnectionHops: [Identifier] //ordered from dest up to self. It starts from 0.
 ) {
 
-    channel = provableStore.get(append(sourceConnectionHops ,channelPath(packet.sourcePort, packet.sourceChannel)))
+    channel = provableStore.get(append(sourceConnectionHops, channelPath(packet.sourcePort, packet.sourceChannel)))
     abortTransactionUnless(channel !== null)
     abortTransactionUnless(channel.state === OPEN)
 

--- a/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
@@ -43,53 +43,13 @@ interface RouteInfo {
 ### Channel Handshake
 
 ```typescript
-// srcConnectionHops is the list of identifiers routing back to the initializing chain
-// destConnectionHops is the list of identifiers routing to the TRY chain
-// NOTE: since srcConnectionHops is routing in the opposite direction, it will contain all the counterparty connection identifiers from the connection identifiers specified by the initializing chain up to this point.
-// For example, if the route specified by the initializing chain is "connection-1/connection-3"
-// Then `routeChanOpenTry` may be called on the router chain with srcConnectionHops: "connection-4", destConnectionHops: "connection-3"
-// where connection-4 is the counterparty connectionID on the router chain to connection-1 on the initializing chain
-// and connection-3 is the connection on the router chain to the next hop in the route which in this case is the TRY chain.
-function routeChanOpenTry(
-    srcConnectionHops: [Identifier],
-    destConnectionHops: [Identifier],
-    provingConnectionIdentifier: Identifier,
-    counterpartyPortIdentifier: Identifier,
-    counterpartyChannelIdentifier: Identifier,
-    initChannel: ChannelEnd,
-    proofInit: CommitmentProof,
-    proofHeight: Height
-) {
-    abortTransactionUnless(len(srcConnectionHops) != 0)
-    abortTransactionUnless(len(destConnectionHops) != 0)
-    route = join(append(srcConnectionHops, destConnectionHops...), "/")
-    included = false
-    for ch in initChannel.connectionHops {
-        if route == ch {
-            included = true
-        }
-    }
-    abortTransactionUnless(included)
-
-    connection = getConnection(provingConnectionIdentifier)
-
-    // verify that proving connection is counterparty of the last src connection hop
-    abortTransactionUnless(srcConnectionHops[len(srcConnectionHops-1)] == connection.counterpartyConnectionIdentifier)
-
-    if srcConnectionHops > 1 {
-        // prove that previous hop stored channel under channel path and prefixed by srcConnectionHops[0:len(srcConnectionHops)-1]
-        path = append(srcConnectionHops[0:len(srcConnectionHops)-1], channelPath(portIdentifier, channelIdentifier))
-        client = queryClient(connection.clientIdentifier)
-        value = protobuf.marshal(initChannel)
-        verifyMembership(client, proofHeight, 0, 0, proofInit, path, value)
-    } else {
-        // prove that previous hop (original source) stored channel under channel path
-        verifyChannelState(connection, proofHeight, proofInit, counterpartyPortIdentifier, counterpartyChannelIdentifier, initChannel)
-    }
-}
-
-// srcConnectionHops is the connection Hops from the TRY chain to the executing router chain
-// destConnectionHops is the connection hops from the executing router chain to the ACK chain.
+// srcConnectionHops is the list of identifiers routing back to the ACK chain
+// destConnectionHops is the list of identifiers routing to the CONFIRM chain
+// NOTE: since srcConnectionHops is routing in the opposite direction, it will contain all the counterparty connection identifiers from the connection identifiers specified by the acking chain up to this point.
+// For example, if the route specified by the acking chain is "connection-1/connection-3"
+// Then `routeChanOpenAck` may be called on the router chain with srcConnectionHops: "connection-4", destConnectionHops: "connection-3"
+// where connection-4 is the counterparty connectionID on the router chain to connection-1 on the acking chain
+// and connection-3 is the connection on the router chain to the next hop in the route which in this case is the CONFIRM chain.
 function routeChanOpenAck(
   srcConnectionHops: [Identifier],
   destConnectionHops: [Identifier],

--- a/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
@@ -56,8 +56,8 @@ function routeChanOpenTry(
     path = append(sourceConnectionHops, channelPath(counterpartyPortIdentifier, counterpartyChannelIdentifier))
     store.set(path, initChannel)
 
-    // store source identifiers -> sourceConnectionHops
-    store(counterpartyPortIdentifier, counterpartyChannelIdentifier, sourceConnectionHops)
+    // store sourceConnectionHops -> source identifiers
+    store(sourceConnectionHops, counterpartyPortIdentifier, counterpartyChannelIdentifier)
 }
 
 function routeChanOpenAck(
@@ -94,8 +94,8 @@ function routeChanOpenAck(
     path = append(sourceConnectionHops, channelPath(counterpartyPortIdentifier, counterpartyChannelIdentifier))
     store.set(path, tryChannel)
 
-    // store source identifiers -> sourceConnectionHops
-    store(counterpartyPortIdentifier, counterpartyChannelIdentifier, sourceConnectionHops)
+    // store sourceConnectionHops -> source identifiers
+    store(sourceConnectionHops, counterpartyPortIdentifier, counterpartyChannelIdentifier)
 }
 
 // similar logic for other handshake methods

--- a/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
@@ -126,7 +126,7 @@ function routeChanOpenAck(
     path = append(provingConnectionIdentifier, srcConnectionHops, channelPath(counterpartyPortIdentifier, counterpartyChannelIdentifier))
 
     // merge destHops into a route and
-    // append the destHops to the routeInfo if it does not already exist.
+    // append the route to the routeInfo if it does not already exist.
     routeInfo = store.get(path)
     route = mergeHops(destHops)
     if routeInfo == nil {
@@ -176,7 +176,7 @@ function routeChanOpenConfirm(
     path = append(provingConnectionIdentifier, srcConnectionHops, channelPath(counterpartyPortIdentifier, counterpartyChannelIdentifier))
 
     // merge destHops into a route and
-    // append the destHops to the routeInfo if it does not already exist.
+    // append the route to the routeInfo if it does not already exist.
     routeInfo = store.get(path)
     route = mergeHops(destHops)
     if routeInfo == nil {

--- a/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
@@ -43,13 +43,13 @@ interface RouteInfo {
 ### Channel Handshake
 
 ```typescript
-// srcConnectionHops is the list of identifiers routing back to the ACK chain
-// destConnectionHops is the list of identifiers routing to the CONFIRM chain
-// NOTE: since srcConnectionHops is routing in the opposite direction, it will contain all the counterparty connection identifiers from the connection identifiers specified by the acking chain up to this point.
-// For example, if the route specified by the acking chain is "connection-1/connection-3"
+// srcConnectionHops is the list of identifiers routing back to the TRY chain
+// destConnectionHops is the list of identifiers routing to the ACK chain
+// NOTE: since srcConnectionHops is routing in the opposite direction, it will contain all the counterparty connection identifiers from the connection identifiers specified by the TRY chain up to this point.
+// For example, if the route specified by the TRY chain is "connection-1/connection-3"
 // Then `routeChanOpenAck` may be called on the router chain with srcConnectionHops: "connection-4", destConnectionHops: "connection-3"
-// where connection-4 is the counterparty connectionID on the router chain to connection-1 on the acking chain
-// and connection-3 is the connection on the router chain to the next hop in the route which in this case is the CONFIRM chain.
+// where connection-4 is the counterparty connectionID on the router chain to connection-1 on the TRY chain
+// and connection-3 is the connection on the router chain to the next hop in the route which in this case is the ACK chain.
 function routeChanOpenAck(
   srcConnectionHops: [Identifier],
   destConnectionHops: [Identifier],

--- a/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
@@ -14,9 +14,13 @@ The following document specifies the interfaces and state machine logic that IBC
 
 ## Technical Specification
 
-### Data Structures
-
 ### Store Paths
+
+#### RouteInfoPath
+
+The route info path stores
+
+### Data Structures
 
 ### Channel Handshake
 
@@ -59,7 +63,7 @@ function routeChanOpenTry(
         path = append(srcConnectionHops[0:len(srcConnectionHops)-1], channelPath(portIdentifier, channelIdentifier))
         client = queryClient(connection.clientIdentifier)
         value = protobuf.marshal(initChannel)
-        verifyMembership(clientState, proofHeight, 0, 0, proofInit, path, value)
+        verifyMembership(client, proofHeight, 0, 0, proofInit, path, value)
     } else {
         // prove that previous hop (original source) stored channel under channel path
         verifyChannelState(connection, proofHeight, proofInit, counterpartyPortIdentifier, counterpartyChannelIdentifier, initChannel)

--- a/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
@@ -23,27 +23,28 @@ The following document specifies the interfaces and state machine logic that IBC
 ```typescript
 function routeChanOpenTry(
     order: ChannelOrder,
-    sourceConnectionHops: [Identifier],
-    destConnectionHops: [Identifier],
+    sourceConnectionHops: Identifier,
+    destConnectionHops: Identifier,
     counterpartyPortIdentifier: Identifier,
     counterpartyChannelIdentifier: Identifier,
     proofInit: CommitmentProof,
     proofHeight: Height
 ) {
-    if len(sourceConnectionHops) == 0 {
+    srcHops = split(sourceConnectionHops, "/")
+    if len(srcHops) == 0 {
         return
     }
-    connection = getConnection(sourceConnectionHops[len(sourceConnectionHops)-1])
-    if sourceConnectionHops > 1 {
-        // prove that previous hop stored channel under channel path and prefixed by sourceConnectionHops[1:]
+    connection = getConnection(srcHops[len(srcHops)-1])
+    if srcHops > 1 {
+        // prove that previous hop stored channel under channel path and prefixed by srcHops[1:]
     } else {
         // prove that previous hop (original source) stored channel under channel path
     }
-    connectionHops = append(sourceConnectionHops, destConnectionHops...)
-    // store channel under channelPath prefixed by sourceConnectionHops
+    connectionHops = append(srcHops, destConnectionHops...)
+    // store channel under channelPath prefixed by srcHops
 
-    // store source identifiers -> sourceConnectionHops
-    store(counterpartyPortIdentifier, counterpartyChannelIdentifier, sourceConnectionHops)
+    // store source identifiers -> srcHops
+    store(counterpartyPortIdentifier, counterpartyChannelIdentifier, srcHops)
 }
 
 // similar logic for other handshake methods

--- a/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
@@ -176,7 +176,7 @@ function routeChanOpenConfirm(
 
     // verification passed, storing the channel under the route prefix
     // note that ackChannel does overwrites the possibly already stored initChannel
-    provableStore.set(append(srcConnectionHops, channelPath(packet.destPort, packet.destChannel)), tryChannel)
+    provableStore.set(append(srcConnectionHops, channelPath(packet.destPort, packet.destChannel)), ackChannel)
 }
 ```
 

--- a/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
@@ -22,33 +22,94 @@ The following document specifies the interfaces and state machine logic that IBC
 
 ```typescript
 function routeChanOpenTry(
-    order: ChannelOrder,
-    sourceConnectionHops: Identifier,
-    destConnectionHops: Identifier,
+    sourceConnectionHops: [Identifier],
+    destConnectionHops: [Identifier],
     counterpartyPortIdentifier: Identifier,
     counterpartyChannelIdentifier: Identifier,
+    initChannel: ChannelEnd,
     proofInit: CommitmentProof,
     proofHeight: Height
 ) {
-    srcHops = split(sourceConnectionHops, "/")
-    if len(srcHops) == 0 {
-        return
+    route = join(append(sourceConnectionHops, destConnectionHops...), "/")
+    included = false
+    for ch in initChannel.connectionHops {
+        if route == ch {
+            included = true
+        }
     }
-    connection = getConnection(srcHops[len(srcHops)-1])
-    if srcHops > 1 {
-        // prove that previous hop stored channel under channel path and prefixed by srcHops[1:]
+    abortTransactionUnless(included)
+    abortTransactionUnless(len(sourceConnectionHops) != 0)
+
+    connection = getConnection(sourceConnectionHops[len(sourceConnectionHops)-1])
+    if sourceConnectionHops > 1 {
+        // prove that previous hop stored channel under channel path and prefixed by sourceConnectionHops[0:len(sourceConnectionHops)-1]
+        path = append(sourceConnectionHops[0:len(sourceConnectionHops)-1], channelPath(portIdentifier, channelIdentifier))
+        client = queryClient(connection.clientIdentifier)
+        value = protobuf.marshal(initChannel)
+        verifyMembership(clientState, proofHeight, 0, 0, proofInit, path, value)
     } else {
         // prove that previous hop (original source) stored channel under channel path
+        verifyChannelState(connection, proofHeight, proofInit, counterpartyPortIdentifier, counterpartyChannelIdentifier, initChannel)
     }
-    connectionHops = append(srcHops, destConnectionHops...)
-    // store channel under channelPath prefixed by srcHops
 
-    // store source identifiers -> srcHops
-    store(counterpartyPortIdentifier, counterpartyChannelIdentifier, srcHops)
+    // store channel under channelPath prefixed by sourceConnectionHops
+    path = append(sourceConnectionHops, channelPath(counterpartyPortIdentifier, counterpartyChannelIdentifier))
+    store.set(path, initChannel)
+
+    // store source identifiers -> sourceConnectionHops
+    store(counterpartyPortIdentifier, counterpartyChannelIdentifier, sourceConnectionHops)
+}
+
+function routeChanOpenAck(
+  sourceConnectionHops: [Identifier],
+  destConnectionHops: [Identifier],
+  counterpartyPortIdentifier: Identifier,
+  counterpartyChannelIdentifier: Identifier,
+  tryChannel: ChannelEnd,
+  proofTry: CommitmentProof,
+  proofHeight: Height) {
+    route = join(append(sourceConnectionHops, destConnectionHops...), "/")
+    included = false
+    for ch in tryChannel.connectionHops {
+        if route == ch {
+            included = true
+        }
+    }
+    abortTransactionUnless(included)
+    abortTransactionUnless(len(sourceConnectionHops) != 0)
+
+    connection = getConnection(sourceConnectionHops[len(sourceConnectionHops)-1])
+    if sourceConnectionHops > 1 {
+        // prove that previous hop stored channel under channel path and prefixed by sourceConnectionHops[0:len(sourceConnectionHops)-1]
+        path = append(sourceConnectionHops[0:len(sourceConnectionHops)-1], channelPath(portIdentifier, channelIdentifier))
+        client = queryClient(connection.clientIdentifier)
+        value = protobuf.marshal(tryChannel)
+        verifyMembership(clientState, proofHeight, 0, 0, proofTry, path, value)
+    } else {
+        // prove that previous hop (original source) stored channel under channel path
+        verifyChannelState(connection, proofHeight, proofTry, counterpartyPortIdentifier, counterpartyChannelIdentifier, tryChannel)
+    }
+
+    // store channel under channelPath prefixed by sourceConnectionHops
+    path = append(sourceConnectionHops, channelPath(counterpartyPortIdentifier, counterpartyChannelIdentifier))
+    store.set(path, tryChannel)
+
+    // store source identifiers -> sourceConnectionHops
+    store(counterpartyPortIdentifier, counterpartyChannelIdentifier, sourceConnectionHops)
 }
 
 // similar logic for other handshake methods
 ```
 
+### Packet Handling
 
+```typescript
+// if path is prefixed by portId and channelId and it is stored by last
+// connection in srcConnectionHops then store under same path prefixed by srcConnectionHops
+function routeChannelData(
+    sourceHops: [Identifier],
+    portIdentifier: Identifier,
+    channelIdentifier: Identifier,
+    path: CommitmentPath
+)
 

--- a/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
@@ -21,16 +21,26 @@ The following document specifies the interfaces and state machine logic that IBC
 ### Channel Handshake
 
 ```typescript
+// srcConnectionHops is the list of identifiers routing back to the initializing chain
+// destConnectionHops is the list of identifiers routing to the TRY chain
+// NOTE: since srcConnectionHops is routing in the opposite direction, it will contain all the counterparty connection identifiers from the connection identifiers specified by the initializing chain up to this point.
+// For example, if the route specified by the initializing chain is "connection-1/connection-3"
+// Then `routeChanOpenTry` may be called on the router chain with srcConnectionHops: "connection-4", destConnectionHops: "connection-3"
+// where connection-4 is the counterparty connectionID on the router chain to connection-1 on the initializing chain
+// and connection-3 is the connection on the router chain to the next hop in the route which in this case is the TRY chain.
 function routeChanOpenTry(
-    sourceConnectionHops: [Identifier],
+    srcConnectionHops: [Identifier],
     destConnectionHops: [Identifier],
+    provingConnectionIdentifier: Identifier,
     counterpartyPortIdentifier: Identifier,
     counterpartyChannelIdentifier: Identifier,
     initChannel: ChannelEnd,
     proofInit: CommitmentProof,
     proofHeight: Height
 ) {
-    route = join(append(sourceConnectionHops, destConnectionHops...), "/")
+    abortTransactionUnless(len(srcConnectionHops) != 0)
+    abortTransactionUnless(len(destConnectionHops) != 0)
+    route = join(append(srcConnectionHops, destConnectionHops...), "/")
     included = false
     for ch in initChannel.connectionHops {
         if route == ch {
@@ -38,12 +48,15 @@ function routeChanOpenTry(
         }
     }
     abortTransactionUnless(included)
-    abortTransactionUnless(len(sourceConnectionHops) != 0)
 
-    connection = getConnection(sourceConnectionHops[len(sourceConnectionHops)-1])
-    if sourceConnectionHops > 1 {
-        // prove that previous hop stored channel under channel path and prefixed by sourceConnectionHops[0:len(sourceConnectionHops)-1]
-        path = append(sourceConnectionHops[0:len(sourceConnectionHops)-1], channelPath(portIdentifier, channelIdentifier))
+    connection = getConnection(provingConnectionIdentifier)
+
+    // verify that proving connection is counterparty of the last src connection hop
+    abortTransactionUnless(srcConnectionHops[len(srcConnectionHops-1)] == connection.counterpartyConnectionIdentifier)
+
+    if srcConnectionHops > 1 {
+        // prove that previous hop stored channel under channel path and prefixed by srcConnectionHops[0:len(srcConnectionHops)-1]
+        path = append(srcConnectionHops[0:len(srcConnectionHops)-1], channelPath(portIdentifier, channelIdentifier))
         client = queryClient(connection.clientIdentifier)
         value = protobuf.marshal(initChannel)
         verifyMembership(clientState, proofHeight, 0, 0, proofInit, path, value)
@@ -52,36 +65,36 @@ function routeChanOpenTry(
         verifyChannelState(connection, proofHeight, proofInit, counterpartyPortIdentifier, counterpartyChannelIdentifier, initChannel)
     }
 
-    // store channel under channelPath prefixed by sourceConnectionHops
-    path = append(sourceConnectionHops, channelPath(counterpartyPortIdentifier, counterpartyChannelIdentifier))
+    // store channel under channelPath prefixed by srcConnectionHops
+    path = append(srcConnectionHops, channelPath(counterpartyPortIdentifier, counterpartyChannelIdentifier))
     store.set(path, initChannel)
 
-    // store sourceConnectionHops -> source identifiers
-    store(sourceConnectionHops, counterpartyPortIdentifier, counterpartyChannelIdentifier)
+    // store srcConnectionHops -> src identifiers
+    store(srcConnectionHops, counterpartyPortIdentifier, counterpartyChannelIdentifier)
 }
 
+// srcConnectionHops is the connection Hops from the TRY chain to the executing router chain
+// destConnectionHops is the connection hops from the executing router chain to the ACK chain.
 function routeChanOpenAck(
-  sourceConnectionHops: [Identifier],
+  srcConnectionHops: [Identifier],
   destConnectionHops: [Identifier],
+  provingConnectionIdentifier: Identifier,
   counterpartyPortIdentifier: Identifier,
   counterpartyChannelIdentifier: Identifier,
   tryChannel: ChannelEnd,
   proofTry: CommitmentProof,
   proofHeight: Height) {
-    route = join(append(sourceConnectionHops, destConnectionHops...), "/")
-    included = false
-    for ch in tryChannel.connectionHops {
-        if route == ch {
-            included = true
-        }
-    }
-    abortTransactionUnless(included)
-    abortTransactionUnless(len(sourceConnectionHops) != 0)
+    abortTransactionUnless(len(srcConnectionHops) != 0)
+    abortTransactionUnless(len(destConnectionHops) != 0)
 
-    connection = getConnection(sourceConnectionHops[len(sourceConnectionHops)-1])
-    if sourceConnectionHops > 1 {
-        // prove that previous hop stored channel under channel path and prefixed by sourceConnectionHops[0:len(sourceConnectionHops)-1]
-        path = append(sourceConnectionHops[0:len(sourceConnectionHops)-1], channelPath(portIdentifier, channelIdentifier))
+    connection = getConnection(provingConnectionIdentifier)
+    
+    // verify that proving connection is counterparty of the last src connection hop
+    abortTransactionUnless(srcConnectionHops[len(srcConnectionHops-1)] == connection.counterpartyConnectionIdentifier)
+
+    if srcConnectionHops > 1 {
+        // prove that previous hop stored channel under channel path and prefixed by srcConnectionHops[0:len(srcConnectionHops)-1]
+        path = append(srcConnectionHops[0:len(srcConnectionHops)-1], channelPath(portIdentifier, channelIdentifier))
         client = queryClient(connection.clientIdentifier)
         value = protobuf.marshal(tryChannel)
         verifyMembership(clientState, proofHeight, 0, 0, proofTry, path, value)
@@ -90,15 +103,45 @@ function routeChanOpenAck(
         verifyChannelState(connection, proofHeight, proofTry, counterpartyPortIdentifier, counterpartyChannelIdentifier, tryChannel)
     }
 
-    // store channel under channelPath prefixed by sourceConnectionHops
-    path = append(sourceConnectionHops, channelPath(counterpartyPortIdentifier, counterpartyChannelIdentifier))
+    // store channel under channelPath prefixed by srcConnectionHops
+    path = append(srcConnectionHops, channelPath(counterpartyPortIdentifier, counterpartyChannelIdentifier))
     store.set(path, tryChannel)
 
-    // store sourceConnectionHops -> source identifiers
-    store(sourceConnectionHops, counterpartyPortIdentifier, counterpartyChannelIdentifier)
+    // store srcConnectionHops -> src identifiers
+    store(srcConnectionHops, counterpartyPortIdentifier, counterpartyChannelIdentifier)
 }
 
-// similar logic for other handshake methods
+function routeChanOpenConfirm(
+    srcConnectionHops: [Identifier],
+    destConnectionHops: [Identifier],
+    provingConnectionIdentifier: Identifier,
+    portIdentifier: Identifier,
+    channelIdentifier: Identifier,
+    ackChannel: ChannelEnd,
+    proofAck: CommitmentProof,
+    proofHeight: Height
+) {
+    abortTransactionUnless(len(srcConnectionHops) != 0)
+    abortTransactionUnless(len(destConnectionHops) != 0)
+
+    connection = getConnection(provingConnectionIdentifier)
+
+    // verify that proving connection is counterparty of the last src connection hop
+    abortTransactionUnless(srcConnectionHops[len(srcConnectionHops-1)] == connection.counterpartyConnectionIdentifier)
+
+    if srcConnectionHops > 1 {
+        // prove that previous hop stored channel under channel path and prefixed by srcConnectionHops[0:len(srcConnectionHops)-1]
+        path = append(srcConnectionHops[0:len(srcConnectionHops)-1], channelPath(portIdentifier, channelIdentifier))
+        client = queryClient(connection.clientIdentifier)
+        value = protobuf.marshal(tryChannel)
+        verifyMembership(clientState, proofHeight, 0, 0, proofTry, path, value)
+    } else {
+        // prove that previous hop (original src) stored channel under channel path
+        verifyChannelState(connection, proofHeight, proofTry, counterpartyPortIdentifier, counterpartyChannelIdentifier, tryChannel)
+    }
+
+
+}
 ```
 
 ### Packet Handling
@@ -107,7 +150,7 @@ function routeChanOpenAck(
 // if path is prefixed by portId and channelId and it is stored by last
 // connection in srcConnectionHops then store under same path prefixed by srcConnectionHops
 function routeChannelData(
-    sourceHops: [Identifier],
+    srcHops: [Identifier],
     portIdentifier: Identifier,
     channelIdentifier: Identifier,
     path: CommitmentPath

--- a/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/ROUTER.md
@@ -18,9 +18,13 @@ The following document specifies the interfaces and state machine logic that IBC
 
 #### RouteInfoPath
 
-The route info path stores
+The route info path includes the connectionID on the executing chain along with the path to the executing chain and the source port and channelID.
 
-### Data Structures
+```typescript
+function routeInfoPath(connectionId: Identifier, route: Identifier, portIdentifier: Identifer, channelIdentifier: Identifier) {
+    return "routeInfo/connectionId/{connectionId}/route/{route}/portIdentifier/{portIdentifier}/channelIdentifier/{channelIdentifier}"
+}
+```
 
 ### Channel Handshake
 
@@ -72,9 +76,6 @@ function routeChanOpenTry(
     // store channel under channelPath prefixed by srcConnectionHops
     path = append(srcConnectionHops, channelPath(counterpartyPortIdentifier, counterpartyChannelIdentifier))
     store.set(path, initChannel)
-
-    // store srcConnectionHops -> src identifiers
-    store(srcConnectionHops, counterpartyPortIdentifier, counterpartyChannelIdentifier)
 }
 
 // srcConnectionHops is the connection Hops from the TRY chain to the executing router chain
@@ -110,11 +111,11 @@ function routeChanOpenAck(
     // store channel under channelPath prefixed by srcConnectionHops
     path = append(srcConnectionHops, channelPath(counterpartyPortIdentifier, counterpartyChannelIdentifier))
     store.set(path, tryChannel)
-
-    // store srcConnectionHops -> src identifiers
-    store(srcConnectionHops, counterpartyPortIdentifier, counterpartyChannelIdentifier)
 }
 
+// routeChanOpenConfirm routes an ACK to the confirmation chain
+// srcConnectionHops is the connectionHops from the ACK chain
+// destConnectionHops is the connectionHops to the CONFIRM chain
 function routeChanOpenConfirm(
     srcConnectionHops: [Identifier],
     destConnectionHops: [Identifier],
@@ -144,7 +145,9 @@ function routeChanOpenConfirm(
         verifyChannelState(connection, proofHeight, proofTry, counterpartyPortIdentifier, counterpartyChannelIdentifier, tryChannel)
     }
 
-
+     // store channel under channelPath prefixed by srcConnectionHops
+    path = append(srcConnectionHops, channelPath(counterpartyPortIdentifier, counterpartyChannelIdentifier))
+    store.set(path, ackChannel)
 }
 ```
 


### PR DESCRIPTION
(WIP)

This PR adds the logic for packet handling required by multihop:
- New router function for packets, acknowledgments and timeout
- Modifies packet handling logic at chain ends

It builds on top of #741 