### PR TITLE
TLA+ spec of CCV

### DIFF
--- a/spec/app/ics-028-cross-chain-validation/tla/CCV.tla
+++ b/spec/app/ics-028-cross-chain-validation/tla/CCV.tla
@@ -327,7 +327,7 @@ PromoteConsumers ==
           \* Either stays INITIALIZING or is dropped ...
           /\ PacketTimeoutForConsumer(c, ccvChannelsPending'[c], currentTimes'[c], currentTimes'[ProviderChain], maturityTimes'[c], maturePackets') =>
             newStatus[c] /= Active
-          \* ... however it must be dropped if it exceed the inactivity timeout
+          \* ... however it must be dropped if it exceeds the inactivity timeout
           /\ TimeoutByInactivity(c, expectedResponders', currentTimes'[ProviderChain], maturePackets') 
             => newStatus[c] = Dropped
         )

--- a/spec/app/ics-028-cross-chain-validation/tla/CCV.tla
+++ b/spec/app/ics-028-cross-chain-validation/tla/CCV.tla
@@ -33,7 +33,7 @@ CONSTANT
   \* Maximal time by which clocks are assumed to differ from the provider chain.
   \* Since consumer chains don't communicate, we don't care about 
   \* drift between two consumers (though it's implicitly less than MaxDrift, if
-  \* each differs from the provider chain by at most MaxDrift).
+  \* each differs from the provider chain by at most 2*MaxDrift).
   \* The specification doesn't force clocks to maintain bounded drift, 
   \* but the invariants are only verified in cases where clocks never drift too far.
   \* @type: $time;

--- a/spec/app/ics-028-cross-chain-validation/tla/CCV.tla
+++ b/spec/app/ics-028-cross-chain-validation/tla/CCV.tla
@@ -579,4 +579,12 @@ We can define change completion, but we don't model it. Best approximation:
 Inv702 ==
   boundedDrift => EventuallyMatureOnProvider
 
+Inv ==
+  /\ Inv411
+  /\ Inv601
+  /\ Inv602
+  /\ Inv603
+  /\ Inv701
+  /\ Inv702
+
 =============================================================================

--- a/spec/app/ics-028-cross-chain-validation/tla/CCV.tla
+++ b/spec/app/ics-028-cross-chain-validation/tla/CCV.tla
@@ -88,10 +88,10 @@ VARIABLES
   \* Bookkeeping of maturity times for received packets.
   \* A consumer may only send a MatureVSCPacket (i.e. notify the provider) after
   \* its local time exceeds the time designated in maturityTimes.
-  \* For each consumer chain c, and VSC packet t sent by the provider,
-  \* a) t \in DOMAIN maturityTimes[c] <=> c has received packet t 
-  \* b) if t \in DOMAIN maturityTimes[c], then maturity for t on c is 
-  \*    guarded by currentTimes[c] >= maturityTimes[c][t]
+  \* For each consumer chain c, and VSC packet p sent by the provider,
+  \* a) p \in DOMAIN maturityTimes[c] <=> c has received packet p 
+  \* b) if p \in DOMAIN maturityTimes[c], then maturity for p on c is 
+  \*    guarded by currentTimes[c] >= maturityTimes[c][p]
   \* @type: $chain -> $packet -> $time;
   maturityTimes
 

--- a/spec/app/ics-028-cross-chain-validation/tla/CCV.tla
+++ b/spec/app/ics-028-cross-chain-validation/tla/CCV.tla
@@ -32,7 +32,7 @@ CONSTANT
   Timeout,
   \* Maximal time by which clocks are assumed to differ from the provider chain.
   \* Since consumer chains don't communicate, we don't care about 
-  \* drift between tow consumers (though it's implicitly less than MaxDrift, if
+  \* drift between two consumers (though it's implicitly less than MaxDrift, if
   \* each differs from the provider chain by at most MaxDrift).
   \* The specification doesn't force clocks to maintain bounded drift, 
   \* but the invariants are only verified in cases where clocks never drift too far.

--- a/spec/app/ics-028-cross-chain-validation/tla/CCV.tla
+++ b/spec/app/ics-028-cross-chain-validation/tla/CCV.tla
@@ -257,8 +257,8 @@ Init ==
   /\ boundedDrift = TRUE
   /\ lastAction = "Init"
 
-\* We combine all (un)delegate actions, as well as (un)bonding actions into an
-\* abstract VotingPowerChange.
+\* We combine anything impacting voting powers, such as (un)delegate actions, (un)bonding actions, slashing, etc.,
+\* into an abstract VotingPowerChange.
 \* Since VPC packets are sent at most once at the end of each block,
 \* the granularity wouldn't have added value to the model.
 VotingPowerChange == 
@@ -273,7 +273,7 @@ VotingPowerChange ==
     /\ UNCHANGED << votingPowerHist, expectedResponders, maturePackets >>
     /\ lastAction' = "VotingPowerChange"
 
-RcvPacket == 
+RcvVPCPacket == 
   \E c \in ActiveConsumers:
     \* There must be a packet to be received
     /\ Len(ccvChannelsPending[c]) /= 0
@@ -292,7 +292,7 @@ RcvPacket ==
     /\ UNCHANGED providerVars
     /\ UNCHANGED currentTimes
     /\ UNCHANGED votingPowerHasChanged
-    /\ lastAction' = "RcvPacket"
+    /\ lastAction' = "RcvVPCPacket"
 
 SendMatureVSCPacket == 
   \E c \in ActiveConsumers:
@@ -383,7 +383,7 @@ EndProviderBlockAndSendPacket ==
 Next == 
   /\\/ EndProviderBlockAndSendPacket
     \/ VotingPowerChange
-    \/ RcvPacket
+    \/ RcvVPCPacket
     \/ SendMatureVSCPacket
     \/ AdvanceTime
   \* Drop timed out, possibly promote rest

--- a/spec/app/ics-028-cross-chain-validation/tla/CCV.tla
+++ b/spec/app/ics-028-cross-chain-validation/tla/CCV.tla
@@ -1,0 +1,582 @@
+--------------------------- MODULE CCV ---------------------------
+(*
+ * Modeling voting power relay between provider- and consumer chains in ICS.
+ *
+ * Simplifications:
+ *   - We only track voting power, not bonded tokens
+ *   - CCV channel creation is atomic and never fails/times out.
+ *   - There is a fixed upper bound on the number of consumer chains.
+ *   - Block height is not modeled.
+ * 
+ * Jure Kukovec, 2022
+ *)
+
+EXTENDS Integers, Sequences, Apalache, typedefs
+
+CONSTANT 
+  \* The set of all nodes, which may take on a validator role.
+  \* node \in Nodes is a validator <=> node \in DOMAIN votingPowerRunning
+  \* @type: Set($node);
+  Nodes, 
+  \* The set of all consumer chains. Consumers may be removed 
+  \* during execution, but not added.
+  \* @type: Set($chain);
+  ConsumerChains, 
+  \* Time that needs to elapse, before a received VPC is considered
+  \* mature on a chain.
+  \* @type: $time;
+  UnbondingPeriod,
+  \* Time that needs to elapse, before a message is considered to have
+  \* timed out (resulting in the removal of the related consumer chain).
+  \* @type: $time;
+  Timeout,
+  \* Maximal time by which clocks are assumed to differ from the provider chain.
+  \* Since consumer chains don't communicate, we don't care about 
+  \* drift between tow consumers (though it's implicitly less than MaxDrift, if
+  \* each differs from the provider chain by at most MaxDrift).
+  \* The specification doesn't force clocks to maintain bounded drift, 
+  \* but the invariants are only verified in cases where clocks never drift too far.
+  \* @type: $time;
+  MaxDrift,
+  \* Maximal duration, w.r.t. the provider chain clock,
+  \* by which non-responsive (initializing) chains are unilaterally dropped.
+  \* See issue #283.
+  \* @type: $time;
+  InactivityTimeout
+
+\* Provider chain only
+VARIABLES
+  \* Snapshots of the voting power on the provider chain, at the times
+  \* when a VPC packet was sent.
+  \* t \in DOMAIN votingPowerHist <=> VPC packet sent at time t
+  \* @type: $packet -> $votingPowerOnChain;
+  votingPowerHist,
+  \* Current voting power on the provider chain. 
+  \* @type: $votingPowerOnChain;
+  votingPowerRunning,
+  \* Current status for each consumer. May be one of: 
+  \* Unused - Initializing - Active - Dropped
+  \* @type: $chain -> STATUS;
+  consumerStatus,
+  \* Set of chains live at the time a packet was sent (who are expected to reply)
+  \* @type: $packet -> Set($chain);
+  expectedResponders,
+  \* The set of MatureVSCPacket sent by consumer chains to the provider chain.
+  \* @type: Set($matureVSCPacket);
+  maturePackets
+
+\* Consumer chains or both
+VARIABLES 
+  \* Representation of the current voting power, as understood by consumer chains.
+  \* Because consumer chains may not arbitrarily modify their own voting power,
+  \* but must instead update in accordance to VPC packets received from the
+  \* provider, it is sufficient to only track the last received packet.
+  \* The voting power on chain c is then equal to votingPowerHist[votingPowerReferences[c]].
+  \* @type: $chain -> $time;
+  votingPowerReferences,
+  \* The queues of VPC packets, waiting to be received by consumer chains.
+  \* Note that a packet being placed in the channel is not considered 
+  \* received by the consumer, until the receive-action is taken.
+  \* @type: $chain -> Seq($packet);
+  ccvChannelsPending,
+  \* The queues of VPC packets, that have been received by consumer chains in the past.
+  \* @type: $chain -> Seq($packet);
+  ccvChannelsResolved,
+  \* The current times of all chains (including the provider).
+  \* @type: $chain -> $time;
+  currentTimes,
+  \* Bookkeeping of maturity times for received packets.
+  \* A consumer may only send a MatureVSCPacket (i.e. notify the provider) after
+  \* its local time exceeds the time designated in maturityTimes.
+  \* For each consumer chain c, and VSC packet t sent by the provider,
+  \* a) t \in DOMAIN maturityTimes[c] <=> c has received packet t 
+  \* b) if t \in DOMAIN maturityTimes[c], then maturity for t on c is 
+  \*    guarded by currentTimes[c] >= maturityTimes[c][t]
+  \* @type: $chain -> $packet -> $time;
+  maturityTimes
+
+\* Bookkeeping
+VARIABLES 
+  \* Name of last action, for debugging
+  \* @type: Str;
+  lastAction,
+  \* VPC flag; Voting power may be considered to have changed, even if 
+  \* the (TLA) value of votingPowerRunning does not (for example, due to a sequence
+  \* of delegations and un-delegations, with a net 0 change in voting power).
+  \* We use this flag to determine whether it is necessary to send a VPC packet.
+  \* @type: Bool;
+  votingPowerHasChanged,
+  \* Invariant flag, TRUE iff clocks never drifted too much
+  \* @type: Bool;
+  boundedDrift
+
+\* Helper tuples for UNCHANGED syntax
+\* We don't track consumerStatus and lastAction in var tuples, because
+\* they change each round.
+
+providerVars ==
+  << votingPowerHist, votingPowerRunning, expectedResponders, maturePackets >>
+
+consumerVars ==
+  << votingPowerReferences, ccvChannelsPending, ccvChannelsResolved, currentTimes, maturityTimes >>
+
+\* @type: <<Bool, Bool>>;
+bookkeepingVars == 
+  << votingPowerHasChanged, boundedDrift >>
+
+
+(*** NON-ACTION DEFINITIONS ***)
+
+Unused == "Unused_OF_STATUS"
+Initializing == "Initializing_OF_STATUS"
+Active == "Active_OF_STATUS"
+Dropped == "Dropped_OF_STATUS"
+
+Status == { Unused, Initializing, Active, Dropped }
+
+ActiveConsumers == {c \in ConsumerChains: consumerStatus[c] = Active }
+InitializingConsumers == {c \in ConsumerChains: consumerStatus[c] = Initializing }
+LiveConsumers == ActiveConsumers \union InitializingConsumers
+LiveNext == { c \in ConsumerChains: consumerStatus'[c] \in {Initializing, Active} }
+InactiveConsumers == {c \in ConsumerChains: consumerStatus[c] \in {Unused, Dropped}}
+
+\* Some value not in Nat, for initialization
+UndefinedTime == -1
+
+\* Provider chain ID, assumed to be distinct from all consumer chain IDs
+ProviderChain == "provider_OF_C"
+
+\* Some value not in [Nodes -> Nat], for initialization
+UndefinedPower == [node \in Nodes |-> -1]
+
+\* All chains, including the provider. Used for the domain of shared
+\* variables, e.g. currentTimes
+Chains == ConsumerChains \union {ProviderChain}
+
+\* According to https://github.com/cosmos/ibc/blob/main/spec/core/ics-004-channel-and-packet-semantics/README.md#receiving-packets
+\* we need to use >=.
+TimeoutGuard(a,b) == a >= b
+
+\* @type: (Seq($packet), $time) => Bool;
+TimeoutOnReception(channel, consumerT) ==
+  /\ Len(channel) /= 0
+  \* Head is always the oldest packet, so if there is a timeout for some packet, 
+  \* there must be one for Head too
+  /\ TimeoutGuard(consumerT, Head(channel) + Timeout)
+
+
+\* @type: ($chain, $time, $packet -> $time, Set($matureVSCPacket)) => Bool;
+TimeoutOnMaturity(c, providerT, maturity, rcvdMature) ==
+  \E packet \in DOMAIN maturity: 
+    \* Note: Reception time = maturity[packet] - UnbondingPeriod
+    /\ TimeoutGuard(providerT + UnbondingPeriod, maturity[packet] + Timeout)
+    \* Not yet matured
+    /\ \A matureVSCPacket \in rcvdMature:
+      \/ matureVSCPacket.chain /= c
+      \/ matureVSCPacket.packet /= packet
+
+\* Takes parameters, so primed and non-primed values can be passed
+\* @type: ($chain, Seq($packet), $time, $time, $packet -> $time, Set($matureVSCPacket)) => Bool;
+PacketTimeoutForConsumer(c, channel, consumerT, providerT, maturity, rcvdMature) == 
+  \* Option 1: Timeout on reception
+  \/ TimeoutOnReception(channel, consumerT)
+  \* Option 2: Timeout on maturity
+  \/ TimeoutOnMaturity(c, providerT, maturity, rcvdMature)
+
+\* Because we're not using functions with fixed domains, we can't use EXCEPT.
+\* Thus, we need a helper method for domain-extension.
+\* @type: (a -> b, a, b) => a -> b;
+ExtendFnBy(f, k, v) ==
+  [ 
+    x \in DOMAIN f \union {k} |->
+      IF x = k
+      THEN v
+      ELSE f[x]
+  ]
+
+\* @type: (Int, Int) => Int;
+Max2(a,b) == IF a >= b THEN a ELSE b
+
+\* Packets are set at unique times, monotonically increasing, the last
+\* one is just the max in the votingPowerHist domain.
+LastPacketTime == ApaFoldSet(Max2, -1, DOMAIN votingPowerHist)
+
+\* @type: ($chain, $packet, $time) => $matureVSCPacket;
+MatureVSCPacket(c, packet, matT) == 
+  [chain |-> c, packet |-> packet, maturityTime |-> matT]
+
+\* @type: (Int, Int) => Int;
+Delta(a,b) == IF a > b THEN a - b ELSE b - a
+
+\* @type: (a -> Int, Set(a), Int) => Bool;
+BoundedDeltas(fn, dom, bound) ==
+  /\ dom \subseteq DOMAIN fn
+  /\ \A v1, v2 \in dom:
+    Delta(fn[v1], fn[v2]) <= bound
+
+\* All the packets ever sent to c in the order they were sent in
+\* @type: ($chain) => Seq($packet);
+PacketOrder(c) == ccvChannelsResolved[c] \o ccvChannelsPending[c]
+
+\* @type: $packet => Set($chain);
+RemainingResponders(t) ==
+  { c \in expectedResponders[t]: consumerStatus[c] /= Dropped }
+
+
+\* Takes parameters, so primed and non-primed values can be passed
+\* @type: ($chain, $packet -> Set($chain), $time, Set($matureVSCPacket)) => Bool;
+TimeoutByInactivity(c, responders, providerT, rcvdMature) ==
+  \E packet \in DOMAIN responders: 
+    \* From the provider chain's time perspective, at least
+    \* InactivityTimeout has elapsed since packet was sent
+    /\ TimeoutGuard(providerT, packet + InactivityTimeout)
+    \* packet was meant for c
+    /\ c \in responders[packet]
+    \* Not yet matured on c
+    /\ \A matureVSCPacket \in rcvdMature:
+      \/ matureVSCPacket.chain /= c
+      \/ matureVSCPacket.packet /= packet
+
+(*** ACTIONS ***)
+
+Init == 
+  /\ votingPowerHist = [t \in {} |-> UndefinedPower]
+  /\ \E initValidators \in SUBSET Nodes:
+    /\ initValidators /= {}
+    /\ votingPowerRunning \in [initValidators -> Nat]
+    /\ \A v \in initValidators: votingPowerRunning[v] > 0
+  /\ consumerStatus \in [ConsumerChains -> Status]
+  /\ expectedResponders = [t \in {} |-> {}]
+  /\ maturePackets = {}
+  /\ votingPowerReferences = [chain \in ConsumerChains |-> UndefinedTime]
+  /\ ccvChannelsPending = [chain \in ConsumerChains |-> <<>>]
+  /\ ccvChannelsResolved = [chain \in ConsumerChains |-> <<>>]
+  /\ currentTimes = [c \in Chains |-> 0]
+  /\ maturityTimes = [c \in ConsumerChains |-> [t \in {} |-> UndefinedTime]]
+  /\ votingPowerHasChanged = FALSE
+  /\ boundedDrift = TRUE
+  /\ lastAction = "Init"
+
+\* We combine all (un)delegate actions, as well as (un)bonding actions into an
+\* abstract VotingPowerChange.
+\* Since VPC packets are sent at most once at the end of each block,
+\* the granularity wouldn't have added value to the model.
+VotingPowerChange == 
+  \E newValidators \in SUBSET Nodes:
+    /\ newValidators /= {}
+    /\ votingPowerRunning' \in [newValidators -> Nat]
+    /\ \A v \in newValidators: votingPowerRunning'[v] > 0
+    \* Note: votingPowerHasChanged' is set to true 
+    \* even if votingPowerRunning' = votingPowerRunning
+    /\ votingPowerHasChanged' = TRUE
+    /\ UNCHANGED consumerVars
+    /\ UNCHANGED << votingPowerHist, expectedResponders, maturePackets >>
+    /\ lastAction' = "VotingPowerChange"
+
+RcvPacket == 
+  \E c \in ActiveConsumers:
+    \* There must be a packet to be received
+    /\ Len(ccvChannelsPending[c]) /= 0
+    /\ LET packet == Head(ccvChannelsPending[c]) IN
+      \* The voting power adjusts immediately, but the matureVSCPacket
+      \* is sent later, on maturity 
+      /\ votingPowerReferences' = [votingPowerReferences EXCEPT ![c] = packet]
+      \* Maturity happens after UnbondingPeriod time has elapsed on c
+      /\ maturityTimes' = [
+        maturityTimes EXCEPT ![c] =
+          ExtendFnBy(maturityTimes[c], packet, currentTimes[c] + UnbondingPeriod)
+        ]
+      /\ ccvChannelsResolved' = [ccvChannelsResolved EXCEPT ![c] = Append(@, packet)]
+    \* Drop from channel, to unblock reception of other packets.
+    /\ ccvChannelsPending' = [ccvChannelsPending EXCEPT ![c] = Tail(@)]
+    /\ UNCHANGED providerVars
+    /\ UNCHANGED currentTimes
+    /\ UNCHANGED votingPowerHasChanged
+    /\ lastAction' = "RcvPacket"
+
+SendMatureVSCPacket == 
+  \E c \in ActiveConsumers:
+    \* Has been received
+    \E packet \in DOMAIN maturityTimes[c]:
+      \* Has matured 
+      /\ currentTimes[c] >= maturityTimes[c][packet] 
+      \* Hasn't been sent before
+      /\ \A matureVSCPacket \in maturePackets:
+        \/ matureVSCPacket.chain /= c
+        \/ matureVSCPacket.packet /= packet
+      /\ maturePackets' = maturePackets \union { MatureVSCPacket(c, packet, currentTimes[c]) }
+      /\ UNCHANGED consumerVars
+      /\ UNCHANGED << votingPowerHist, votingPowerRunning, expectedResponders >>
+      /\ UNCHANGED votingPowerHasChanged
+      /\ lastAction' = "SendMatureVSCPacket"
+
+\* Partial action, always happens on Next
+\* Each consumer status advances (or is unchanged) in the
+\* Unused -> Initializing -> Active -> Dropped order
+PromoteConsumers ==
+  \E newStatus \in [ConsumerChains -> Status]:
+    /\ \A c \in ConsumerChains:
+      \* No regressions
+      /\ consumerStatus[c] = Initializing => newStatus[c] /= Unused
+      /\ consumerStatus[c] = Active => newStatus[c] \in {Active, Dropped}
+      /\ consumerStatus[c] = Dropped => newStatus[c] = Dropped
+      \* All timed out chains are dropped
+      /\ consumerStatus[c] \in {Active, Initializing} =>
+        (
+          \* Only ACTIVE chains may time out (not INITIALIZING) 
+          \* Either stays INITIALIZING or is dropped ...
+          /\ PacketTimeoutForConsumer(c, ccvChannelsPending'[c], currentTimes'[c], currentTimes'[ProviderChain], maturityTimes'[c], maturePackets') =>
+            newStatus[c] /= Active
+          \* ... however it must be dropped if it exceed the inactivity timeout
+          /\ TimeoutByInactivity(c, expectedResponders', currentTimes'[ProviderChain], maturePackets') 
+            => newStatus[c] = Dropped
+        )
+    /\ consumerStatus' = newStatus
+  
+      
+\* Partial action, always happens on EndBlock, may also happen independently
+AdvanceTimeCore ==
+  \E newTimes \in [Chains -> Nat]:
+    \* None regress
+    \* Does not guarantee strict time progression in AdvanceTime.
+    \* In EndProviderBlockAndSendPacket, provider time is forced 
+    \* to strictly progress with an additional constraint.
+    /\ \A c \in Chains: newTimes[c] >= currentTimes[c]
+    /\ currentTimes' = newTimes
+
+\* Time may also elapse without EndProviderBlockAndSendPacket.
+AdvanceTime ==
+  /\ AdvanceTimeCore
+  /\ UNCHANGED providerVars
+  /\ UNCHANGED << votingPowerReferences, ccvChannelsPending, ccvChannelsResolved, maturityTimes >>
+  /\ UNCHANGED votingPowerHasChanged
+  /\ lastAction' = "AdvanceTime"
+
+EndProviderBlockAndSendPacket ==
+  \* Packets are only sent if there is a VPC
+  /\ votingPowerHasChanged
+  /\ LET packet == currentTimes[ProviderChain] IN
+    /\ ccvChannelsPending' = 
+      [
+        chain \in ConsumerChains |-> 
+          IF chain \in LiveConsumers
+          THEN 
+            Append(
+              ccvChannelsPending[chain], 
+              \* a packet is just the current time, the VP can be read from votingPowerHist
+              currentTimes[ProviderChain]
+            )
+          ELSE ccvChannelsPending[chain]
+      ]
+    /\ votingPowerHist' = ExtendFnBy(votingPowerHist, packet, votingPowerRunning)
+    \* All currently live (= Active or Init) consumers are expected to respond to this packet
+    /\ expectedResponders' = ExtendFnBy(expectedResponders, packet, LiveConsumers)
+  \* Reset flag for next block
+  /\ votingPowerHasChanged' = FALSE 
+  \* packet sending forces time progression on provider
+  /\ AdvanceTimeCore
+  /\ currentTimes'[ProviderChain] > currentTimes[ProviderChain]
+  /\ UNCHANGED <<votingPowerReferences, maturityTimes, ccvChannelsResolved>>
+  /\ UNCHANGED <<votingPowerRunning, maturePackets>>
+  /\ lastAction' = "EndProviderBlockAndSendPacket"
+
+Next == 
+  /\\/ EndProviderBlockAndSendPacket
+    \/ VotingPowerChange
+    \/ RcvPacket
+    \/ SendMatureVSCPacket
+    \/ AdvanceTime
+  \* Drop timed out, possibly promote rest
+  /\ PromoteConsumers
+  /\ boundedDrift' = boundedDrift /\
+    BoundedDeltas(currentTimes', LiveNext \union {ProviderChain}, MaxDrift)
+
+(*** PROPERTIES/INVARIANTS ***)
+
+\* VCS must also mature on provider
+LastVCSMatureOnProvider ==
+  LastPacketTime + UnbondingPeriod <= currentTimes[ProviderChain]
+
+VPCUpdateInProgress == 
+  \* some chain has pending packets
+  \/ \E c \in LiveConsumers: 
+    \/ Len(ccvChannelsPending[c]) /= 0
+    \/ \E packet \in DOMAIN maturityTimes[c]: maturityTimes[c][packet] < currentTimes[c]
+  \* not enough time has elapsed on provider itself since last update
+  \/ ~LastVCSMatureOnProvider
+
+LiveConsumersNotTimedOut ==
+  \A c \in LiveConsumers:
+    ~PacketTimeoutForConsumer(c, ccvChannelsPending[c], currentTimes[c], currentTimes[ProviderChain], maturityTimes[c], maturePackets)
+
+\* Sanity- predicates check that the data structures don't take on unexpected values
+SanityVP == 
+  /\ \A t \in DOMAIN votingPowerHist:
+    LET VP == votingPowerHist[t] IN
+    VP /= UndefinedPower <=> 
+      \A node \in DOMAIN VP: VP[node] >= 0
+  /\ \A node \in DOMAIN votingPowerRunning: votingPowerRunning[node] >= 0
+
+SanityRefs ==
+  \A c \in ConsumerChains:
+    votingPowerReferences[c] < 0 <=> votingPowerReferences[c] = UndefinedTime
+
+SanityMaturity ==
+  \A c \in ConsumerChains:
+    \A t \in DOMAIN maturityTimes[c]:
+      LET mt == maturityTimes[c][t] IN
+      mt < 0 <=> mt = UndefinedTime
+  
+Sanity ==
+  /\ SanityVP
+  /\ SanityRefs
+  /\ SanityMaturity
+
+
+\* Since the clocks may drift, any delay that exceeds
+\* Timeout + MaxDrift is perceived as timeout on all chains
+AdjustedTimeout == Timeout + MaxDrift
+
+\* Any packet sent by the provider is either received within Timeout, or
+\* the consumer chain is no longer considered active.
+ReceptionBeforeTimeout ==
+  \A packet \in DOMAIN votingPowerHist:
+    \A c \in RemainingResponders(packet):
+      (
+        \* If c is active after Timeout has elapsed from packet t broadcast ...
+        /\ consumerStatus[c] = Active
+        /\ TimeoutGuard(currentTimes[c], packet + AdjustedTimeout)
+      ) =>
+        \* ... then c must have received packet
+        packet \in DOMAIN maturityTimes[c]
+
+\* Any packet received by the consumer matures within Timeout of reception, 
+\* or the consumer is no longer considered active.
+MaturedBeforeTimeout ==
+  \A packet \in DOMAIN votingPowerHist:
+    \A c \in RemainingResponders(packet):
+      \* The following implies t is ACTIVE, since INITIALIZING chains
+      \* don't receive packets.
+      packet \in DOMAIN maturityTimes[c] => 
+      \* If c is still active after Timeout has elapsed from packet reception ...
+      \* Note: Reception time = maturityTimes[c][p] - UnbondingPeriod
+      (
+        TimeoutGuard(currentTimes[ProviderChain] + UnbondingPeriod, maturityTimes[c][packet] + AdjustedTimeout) =>
+        \* ... then packet t must have matured on c
+        \E matureVSCPacket \in maturePackets:
+          /\ matureVSCPacket.chain = c
+          /\ matureVSCPacket.packet = packet
+      )
+
+\* Note that InactivityTimeout >= 2 * AdjustedTimeout if CInit is used,
+\* so this UltimateCutoff = InactivityTimeout in that case.
+\* However, we write the invariants w/o relying on CInit assumptions.
+UltimateCutoff == Max2(InactivityTimeout, 2 * AdjustedTimeout)
+
+\* All packets mature at the latest by UltimateCutoff, from all 
+\* active consumers (or those consumers are removed from the active set)
+\* It should be the case that ReceptionBeforeTimeout /\ MaturedBeforeTimeout => EventuallyMatureOnProvider
+EventuallyMatureOnProvider == 
+  \A packet \in DOMAIN votingPowerHist:
+    \* If a packet was sent at time t and enough time has elapsed, 
+    \* s.t. all consumers should have responded ...
+    TimeoutGuard(currentTimes[ProviderChain], packet + UltimateCutoff) =>
+        \* then, all consumers have matured
+        \A c \in RemainingResponders(packet):
+          \E matureVSCPacket \in maturePackets:
+            /\ matureVSCPacket.chain = c
+            /\ matureVSCPacket.packet = packet
+
+
+\* Invariants from https://github.com/cosmos/interchain-security/blob/main/docs/quality_assurance.md
+
+(* 
+4.10 - The provider chain's correctness is not affected by a consumer chain 
+shutting down
+
+What is "provider chain correctness"?
+*)
+
+(* 
+4.11 - The provider chain can graciously handle a CCV packet timing out 
+(without shutting down) - expected outcome: 
+consumer chain shuts down and its state in provider CCV module is removed
+*)
+Inv411 == 
+  boundedDrift =>
+  \A c \in ConsumerChains:
+    /\ TimeoutOnReception(ccvChannelsPending[c], currentTimes[c]) =>
+      c \notin ActiveConsumers
+    /\ TimeoutByInactivity(c, expectedResponders, currentTimes[ProviderChain], maturePackets) =>
+      c \notin LiveConsumers
+    
+
+(* 
+4.12 - The provider chain can graciously handle a StopConsumerChainProposal - 
+expected outcome: consumer chain shuts down and its state 
+in provider CCV module is removed.
+
+What is "graciously handle"?
+*)
+  
+(*
+6.01 - Every validator set on any consumer chain MUST either be or have been 
+a validator set on the provider chain.
+
+In the current model, implicit through construction (votingPowerReferences)
+*)
+Inv601 ==
+  \A c \in LiveConsumers:
+    LET ref == votingPowerReferences[c] IN
+    ref /= UndefinedTime => ref \in DOMAIN votingPowerHist
+
+(*
+6.02 - Any update in the power of a validator val on the provider, as a result of
+- (increase) Delegate() / Redelegate() to val
+- (increase) val joining the provider validator set
+- (decrease) Undelegate() / Redelegate() from val
+- (decrease) Slash(val)
+- (decrease) val leaving the provider validator set
+MUST be present in a ValidatorSetChangePacket that is sent to all registered consumer chains
+*)
+Inv602 ==
+  \A packet \in DOMAIN votingPowerHist:
+    \A c \in LiveConsumers:
+      LET packetsToC == PacketOrder(c) IN
+      \E i \in DOMAIN packetsToC:
+        packetsToC[i] = packet
+
+(*
+6.03 - Every consumer chain receives the same sequence of 
+ValidatorSetChangePackets in the same order.
+
+Note: consider only prefixes on received packets (ccvChannelsResolved)
+*)
+Inv603 == 
+  \A c1,c2 \in LiveConsumers:
+    \A i \in (DOMAIN ccvChannelsResolved[c1] \intersect DOMAIN ccvChannelsResolved[c2]):
+      ccvChannelsResolved[c1][i] = ccvChannelsResolved[c2][i]
+
+(*
+7.01 - For every ValidatorSetChangePacket received by a consumer chain at 
+time t, a MaturedVSCPacket is sent back to the provider in the first block 
+with a timestamp >= t + UnbondingPeriod
+
+Modification: not necessarily _first_ block with that timestamp, 
+since we don't model height _and_ time. Also, only true for ACTIVE chains.
+*)
+Inv701 ==
+  boundedDrift => MaturedBeforeTimeout
+
+(*
+7.02 - If an unbonding operation resulted in a ValidatorSetChangePacket sent
+to all registered consumer chains, then it cannot complete before receiving
+matching MaturedVSCPackets from these consumer chains 
+(unless some of these consumer chains are removed)
+
+We can define change completion, but we don't model it. Best approximation:
+*)
+Inv702 ==
+  boundedDrift => EventuallyMatureOnProvider
+
+=============================================================================

--- a/spec/app/ics-028-cross-chain-validation/tla/CCV.tla
+++ b/spec/app/ics-028-cross-chain-validation/tla/CCV.tla
@@ -40,7 +40,7 @@ CONSTANT
   MaxDrift,
   \* Maximal duration, w.r.t. the provider chain clock,
   \* by which non-responsive (initializing) chains are unilaterally dropped.
-  \* See issue #283.
+  \* See issue #283 in the interchain security repo: https://github.com/cosmos/interchain-security/issues/283.
   \* @type: $time;
   InactivityTimeout
 

--- a/spec/app/ics-028-cross-chain-validation/tla/CCV.tla
+++ b/spec/app/ics-028-cross-chain-validation/tla/CCV.tla
@@ -32,8 +32,8 @@ CONSTANT
   Timeout,
   \* Maximal time by which clocks are assumed to differ from the provider chain.
   \* Since consumer chains don't communicate, we don't care about 
-  \* drift between two consumers (though it's implicitly less than MaxDrift, if
-  \* each differs from the provider chain by at most 2*MaxDrift).
+  \* drift between two consumers (though it's implicitly less than 2*MaxDrift, if
+  \* each differs from the provider chain by at most MaxDrift).
   \* The specification doesn't force clocks to maintain bounded drift, 
   \* but the invariants are only verified in cases where clocks never drift too far.
   \* @type: $time;

--- a/spec/app/ics-028-cross-chain-validation/tla/MC_CCV.tla
+++ b/spec/app/ics-028-cross-chain-validation/tla/MC_CCV.tla
@@ -1,0 +1,66 @@
+--------------------------- MODULE MC_CCV ---------------------------
+
+EXTENDS Integers
+
+Nodes == {"1_OF_N", "2_OF_N", "3_OF_N", "4_OF_N"}
+ConsumerChains == {"1_OF_C", "2_OF_C", "3_OF_C", "4_OF_C"}
+
+CONSTANT 
+  \* @type: $time;
+  UnbondingPeriod,
+  \* @type: $time;
+  Timeout,
+  \* @type: $time;
+  MaxDrift,
+  \* @type: $time;
+  InactivityTimeout
+
+CInit ==
+  /\ UnbondingPeriod \in Nat
+  /\ Timeout \in Nat
+  /\ MaxDrift \in Nat
+  /\ MaxDrift < Timeout
+  /\ InactivityTimeout \in Nat
+  \* Inactivity cutoff has to be no less than than 
+  \* the largest reasonable round-trip time
+  /\ InactivityTimeout >= 2 * (Timeout + MaxDrift)
+
+
+\* Provider chain only
+VARIABLES
+  \* @type: $time -> $votingPowerOnChain;
+  votingPowerHist,
+  \* @type: $votingPowerOnChain;
+  votingPowerRunning,
+  \* @type: $chain -> STATUS;
+  consumerStatus,
+  \* @type: $packet -> Set($chain);
+  expectedResponders,
+  \* @type: Set($matureVSCPacket);
+  maturePackets
+
+\* Consumer chains or both
+VARIABLES  
+  \* @type: $chain -> $time;
+  votingPowerReferences,
+  \* @type: $chain -> Seq($packet);
+  ccvChannelsPending,
+  \* @type: $chain -> Seq($packet);
+  ccvChannelsResolved,
+  \* @type: $chain -> $time;
+  currentTimes,
+  \* @type: $chain -> $time -> $time;
+  maturityTimes
+
+\* Bookkeeping
+VARIABLES 
+  \* @type: Str;
+  lastAction,
+  \* @type: Bool;
+  votingPowerHasChanged,
+  \* @type: Bool;
+  boundedDrift
+
+INSTANCE CCV
+
+=============================================================================

--- a/spec/app/ics-028-cross-chain-validation/tla/README.md
+++ b/spec/app/ics-028-cross-chain-validation/tla/README.md
@@ -1,0 +1,111 @@
+# Modeling and checking cross-chain validaiton
+
+The file `CCV.tla` contains a TLA+ specification of a simplified version of cross-chain validation, with the following restrictions:
+  
+  - We only track voting power, not bonded tokens
+  - CCV channel creation is atomic and never fails/times out.
+  - There is a fixed upper bound on the number of consumer chains. 
+  - Block height is not modeled.
+
+# Parameterization
+
+The specification uses the following parameters:
+
+  - `Nodes: Set(N)`: The set of all nodes, which may take on a validator role. At every given point in time, the set of currently recognized validators is a nonempty subset of `Nodes`.
+  - `ConsumerChains: Set(C)`: An upper bound on participating consumer chains. At every given point in time, every element `c` of `ConsumerChains` is in one of four distinct states: `Unused`, `Initializing`, `Active`, or `Dropped`
+    - `Unused` chains are not treated as consumers w.r.t. the provider chain, but may become consumers in the future.
+    - `Initializing` chains are considered consumers w.r.t. the provider chain, in a state of initialization (modeling the establishment of the communication channel). They receive all messages broadcast by the provider, but cannot respond until their status changes.
+    - `Active` chains are considered consumers w.r.t. the provider chain, with a fully established communication channel. They may send and receive messages.
+    - `Dropped` chains are not treated as consumers w.r.t. the provider chain, and may never become consumers (again).
+  - `UnbondingPeriod: Int`: Time that needs to elapse, before a received VPC is considered mature on a chain.
+  - `Timeout: Int`: Time that needs to elapse on the provider chain after having sent a message to an `Active` chain, to which no reply was received, before that message is considered to have timed out (resulting in the removal of the related consumer chain).
+  - `MaxDrift: Int`: Maximal time by which clocks are assumed to differ from the provider chain. The specification doesn't force clocks to maintain bounded drift, but the invariants are only verified in cases where clocks never drift too far.
+  - `InactivityTimeout: Int`: Time that needs to elapse on the provider chain after having sent a message to an `Initializing` chain, to which no reply was received, before that message is considered to have timed out (resulting in the removal of the related consumer chain).
+
+# Model variables
+
+The mutable system components modeled are as follows:
+
+  - Provider chain only:
+    - `votingPowerRunning: N -> Int`: Current voting power on the provider chain of all validator nodes. The following holds true: `node \in Nodes` is a validator iff `node \in DOMAIN votingPowerRunning`.
+    - `votingPowerHist: Int -> (N -> Int)`: Snapshots of the voting power on the provider chain, at the times when a VPC packet was sent. The following holds true: `t \in DOMAIN votingPowerHist` iff VPC packet sent at time `t`.
+    - `consumerStatus: C -> STATUS`: Current status for each chain in `ConsumerChains`. May be one of: `Unused`, `Initializing`, `Active`, `Dropped`.
+    - `expectedResponders: Int -> Set(C)`: The set of chains live at the time a packet was sent (who are expected to reply). A chain is live, if it is either `Initializing` or `Active`.
+    - `maturePackets: Set(matureVSCPacket)`: The set of `MatureVSCPacket`s sent by consumer chains to the provider chain.
+  - Consumer chains or both:
+    - `votingPowerReferences: C -> Int`: Representation of the current voting power, as understood by consumer chains. Because consumer chains may not arbitrarily modify their own voting power, but must instead update in accordance to VPC packets received from the provider, it is sufficient to only track the last received packet. The voting power on chain `c` is then equal to `votingPowerHist[votingPowerReferences[c]]`.
+    - `ccvChannelsPending: C -> Seq(Int)`: The queues of VPC packets, waiting to be received by consumer chains. Note that a packet being placed in the channel is not considered received by the consumer, until the receive-action is taken.
+    - `ccvChannelsResolved: C -> Seq(Int)`: The queues of VPC packets, that have been received by consumer chains in the past.
+    - `currentTimes: C -> Int`: The current clocks of all chains (including the provider).
+    - `maturityTimes: C -> Int -> Int`: Bookkeeping of maturity times for received packets. A consumer may only send a `MatureVSCPacket` (i.e. notify the provider) after its local time exceeds the time designated in `maturityTimes`. For each consumer chain `c`, and VSC packet `t` sent by the provider, the following holds true:
+      - `t \in DOMAIN maturityTimes[c]` iff `c` has received packet `t`.
+      - if `t \in DOMAIN maturityTimes[c]`, then maturity for `t` on `c` is reached when `currentTimes[c] >= maturityTimes[c][t]`.
+  - Bookkeeping:
+    - `lastAction: Str`: Name of the last action taken, for debugging.
+    - `votingPowerHasChanged: Bool`: We use this flag to determine whether it is necessary to send a VPC packet.
+    - `boundedDrift: Bool`: Invariant flag, TRUE iff clocks never drifted too much
+
+# System actions
+
+The following actions are modeled:
+  
+  - `VotingPowerChange`: 
+    - Prerequisite(s): None.
+    - Effect(s): 
+        - Modifies `votingPowerRunning` and sets `votingPowerHasChanged` to `TRUE`. 
+        - May change the set of current validators.
+  - `EndProviderBlockAndSendPacket`: 
+    - Prerequisite(s): `votingPowerHasChanged` is `TRUE`.
+    - Effect(s): 
+        - Sends packet to all currently live consumers' queues.
+        - Resets `votingPowerHasChanged` to `FALSE`.
+        - Provider clock advances, consumer clocks may advance.
+  - `RcvPacket`: 
+    - Prerequisite(s): There exists a consumer chain `c` with a nonempty packet queue.
+    - Effect(s):
+        - Adjusts `votingPowerReferences` at `c` to the head packet.
+        - Moves the packet from `ccvChannelsPending[c]` to `ccvChannelsResolved[c]`.
+        - Determines future maturity point (in `maturityTimes`).
+  - `SendMatureVSCPacket`:
+    - Prerequisite(s): 
+        - There exists a consumer chain `c` with a received packet `p`.
+        - The current local clock of `c` is at least `maturityTimes[c][p]`.
+        - `MatureVSCPacket` response has not yet been sent by `c` for `p`.
+    - Effect(s): `MatureVSCPacket` is added to `maturePackets` for the pair `c` and `p`.
+  - `AdvanceTime`:
+    - Prerequisite(s): None.
+    - Effect(s): Local clocks may advance for the provider and any of the consumers.
+
+Additionally, after every action, consumer chain statuses may promote, following the below restrictions:
+  
+  - Each consumer chain's state may remain unchanged
+  - `Unused` chains may become `Initializing`, `Active` or `Dropped`
+  - `Initializing` chains may become `Active` or `Dropped`
+  - `Active` chains may become `Dropped`
+  - `Active` chains _must_ become dropped, if their packets time out either on reception, or on signaling maturity (w.r.t `Timeout`).
+  - `Initializing` chains _must_ become dropped, if they do not signal maturity by `InactivityTimeout` (time measured solely on the provider chain).
+
+# Invariants
+
+The specification implements the following invarians from [this table](https://github.com/cosmos/interchain-security/blob/main/docs/quality_assurance.md): 4.11, 6.01, 6.02, 6.03, 7.01, and 7.02 as
+`Inv411`, `Inv601`, `Inv602`, `Inv603`, `Inv701` and `Inv702` respectively.
+See the specification for details and adjustments.
+
+# Testing
+
+We've tested the specification with the [Apalache](https://github.com/informalsystems/apalache/) model checker.
+
+Last test: November 2022
+
+Invariant tested: 
+```
+Inv ==
+  /\ Inv411
+  /\ Inv601
+  /\ Inv602
+  /\ Inv603
+  /\ Inv701
+  /\ Inv702
+```
+
+Outcome: No invariant violation found in 9 steps.

--- a/spec/app/ics-028-cross-chain-validation/tla/README.md
+++ b/spec/app/ics-028-cross-chain-validation/tla/README.md
@@ -87,7 +87,7 @@ Additionally, after every action, consumer chain statuses may promote, following
 
 # Invariants
 
-The specification implements the following invarians from [this table](https://github.com/cosmos/interchain-security/blob/main/docs/quality_assurance.md): 4.11, 6.01, 6.02, 6.03, 7.01, and 7.02 as
+The specification implements the following invarians from [this table](https://github.com/cosmos/interchain-security/blob/6036419de667590518cccd1c8fcae0d01cbe67e9/docs/old/quality_assurance.md): 4.11, 6.01, 6.02, 6.03, 7.01, and 7.02 as
 `Inv411`, `Inv601`, `Inv602`, `Inv603`, `Inv701` and `Inv702` respectively.
 See the specification for details and adjustments.
 

--- a/spec/app/ics-028-cross-chain-validation/tla/typedefs.tla
+++ b/spec/app/ics-028-cross-chain-validation/tla/typedefs.tla
@@ -1,0 +1,12 @@
+--------------------------- MODULE typedefs ---------------------------
+(* 
+  @typeAlias: chain = C; chain type
+  @typeAlias: node = N; node type
+  @typeAlias: power = Int; voting power
+  @typeAlias: time = Int; 
+  @typeAlias: votingPowerOnChain = $node -> $power;
+  @typeAlias: packet = $time;
+  @typeAlias: matureVSCPacket = {chain: $chain, packet: $packet, maturityTime: $time};
+*)
+AliasesCVV == TRUE
+=============================================================================


### PR DESCRIPTION
This PR ports and updates the previously created CCV TLA+ spec from https://github.com/cosmos/interchain-security/tree/jk/ISaudit.
It includes additional modeling of provider-side timeout.