### PR TITLE
[DRAFT] Client update incentivization

### DIFF
--- a/spec/app/ics-029-fee-payment/README.md
+++ b/spec/app/ics-029-fee-payment/README.md
@@ -97,7 +97,7 @@ Alternate flow:
 1. Relayer submits `OnTimeout` which provides its address on the source chain
 1. Source application can distribute the tokens escrowed in (1) to this relayer, and potentially return remainder tokens to the original fee payer(s).
 
-### Fee details
+### Packet Fee details
 
 For an example implementation in the Cosmos SDK, we consider 3 potential fee payments, which may be defined. Each one may be
 paid out in a different token. Imagine a connection between IrisNet and the Cosmos Hub. To incentivize a packet from IrisNet to the Cosmos Hub, they may define:
@@ -115,16 +115,31 @@ The logic involved in collecting fees from users and then paying it out to the r
 
 ### Data Structures
 
-The incentivized acknowledgment written on the destination chain includes:
+The incentivized packet acknowledgment written on the destination chain includes:
 - raw bytes of the acknowledgement from the underlying application,
 - the source address of the forward relayer,
 - and a boolean indicative of receive operation success on the underlying application.
 
 ```typescript
-interface Acknowledgement {
+interface IncentivizedPacketAcknowledgement {
     appAcknowledgement: []byte
     forwardRelayerAddress: string
     underlyingAppSuccess: boolean
+}
+```
+
+The incentivized client update written on the destination chain includes:
+- the client id on the destination chain
+- raw bytes of the client update msg
+- the latest updated height
+- the source address of the forward relayer
+
+```typescript
+interface IncentivizedClientUpdate {
+    clientID: string
+    clientMsg: []byte
+    forwardRelayerAddress: string
+    height: Height
 }
 ```
 

--- a/spec/core/ics-026-routing-module/README.md
+++ b/spec/core/ics-026-routing-module/README.md
@@ -157,7 +157,8 @@ function onTimeoutPacketClose(packet: Packet, relayer: string) {
 
 `onClientUpdate` propagates information on client updates up to the application layer
 including the relayer responsible for posting the update. This allows relayer incentivization
-for client updates to be built at the application layer.
+for client updates to be built at the application layer. This method is only called upon a 
+successful client update.
 
 ```typescript
 function onClientUpdate(

--- a/spec/core/ics-026-routing-module/README.md
+++ b/spec/core/ics-026-routing-module/README.md
@@ -153,6 +153,23 @@ function onTimeoutPacketClose(packet: Packet, relayer: string) {
 }
 ```
 
+#### **OnClientUpdate**
+
+`onClientUpdate` propagates information on client updates up to the application layer
+including the relayer responsible for posting the update. This allows relayer incentivization
+for client updates to be built at the application layer.
+
+```typescript
+function onClientUpdate(
+  clientID: Identifier,
+  clientUpdate: ClientMsg,
+  updateHeights: []Height,
+  relayer: string) => (err: Error) {
+    // defined by the module
+}
+```
+
+
 Exceptions MUST be thrown to indicate failure and reject the handshake, incoming packet, etc.
 
 These are combined together in a `ModuleCallbacks` interface:


### PR DESCRIPTION
Client updates are not currently incentivized within ICS-29. 

This PR extends the ICS-29 spec with additional logic to escrow and pay out rewards for posting client updates. ICS-29 is extended instead of a creating a separate app spec because relayer registration is required for incentivized client updates as well.