### PR TITLE
ics4-add active client check in sendpacket

### DIFF
--- a/spec/client/ics-006-solo-machine-client/README.md
+++ b/spec/client/ics-006-solo-machine-client/README.md
@@ -212,6 +212,20 @@ function verifyMisbehaviour(misbehaviour: Misbehaviour) {
 }
 ```
 
+### Retrieve client status 
+
+Return the status of the solo machine client. Status can be either `Active` or `Frozen`.
+
+```typescript
+// returns the status of a client
+function Status (clientIdentifier: Identifier, clientState: clientState): Status {
+  if clientState.frozen == true
+    return Frozen
+  }
+  return Active
+} 
+```
+
 ### Misbehaviour predicate
 
 Since misbehaviour is checked in `verifyClientMessage`, if the client message is of type `Misbehaviour` then we return true:

--- a/spec/client/ics-007-tendermint-client/README.md
+++ b/spec/client/ics-007-tendermint-client/README.md
@@ -238,6 +238,31 @@ function verifyHeader(header: Header) {
 }
 ```
 
+### Retrieve Client Status 
+
+Return the Status of the Tendermint client. Status can be either Active, Expired, Unknown or Frozen. 
+
+```typescript
+// Returns the status of a client given its store.
+function Status (client: clientState) {
+  if (client.FrozenHeight !== 0) {
+    return Frozen
+  }
+  // Get latest consensus state from clientStore to check for expiry
+  consState, err := client.latestClientHeight()
+  if err (!== nil) {
+    return Unknown
+  }
+  // Check if Expired
+  let expirationTime := consState.Timestamp + client.TrustingPeriod
+  if (expirationTime <== now){
+    return Expired 
+  }
+
+  return Active
+} 
+```
+
 ### Misbehaviour predicate
 
 Function `checkForMisbehaviour` will check if an update contains evidence of Misbehaviour. If the ClientMessage is a header we check for implicit evidence of misbehaviour by checking if there already exists a conflicting consensus state in the store or if the header breaks time monotonicity.

--- a/spec/client/ics-007-tendermint-client/README.md
+++ b/spec/client/ics-007-tendermint-client/README.md
@@ -238,27 +238,27 @@ function verifyHeader(header: Header) {
 }
 ```
 
-### Retrieve Client Status 
+### Retrieve client status 
 
-Return the Status of the Tendermint client. Status can be either Active, Expired, Unknown or Frozen. 
+Return the Status of the Tendermint client. Status can be either `Active`, `Expired` or `Frozen`.
 
 ```typescript
-// Returns the status of a client given its store.
-function Status (client: clientState) {
-  if (client.FrozenHeight !== 0) {
+// returns the status of a client
+function Status (clientIdentifier: Identifier, clientState: clientState): Status {
+  if (clientState.frozenHeight !== 0) {
     return Frozen
   }
-  // Get latest consensus state from clientStore to check for expiry
-  consState, err := client.latestClientHeight()
-  if err (!== nil) {
-    return Unknown
+  // get consensus state for the latest height
+  height = clientState.latestClientHeight()
+  consensusState = provableStore.get("clients/{clientIdentifier}/consensusStates/{height}")
+  if consensusState == nil {
+    return Expired
   }
-  // Check if Expired
-  let expirationTime := consState.Timestamp + client.TrustingPeriod
-  if (expirationTime <== now){
+  // check if the trusting period has passed since the last update
+  let expirationTime := consensusState.timestamp + clientState.trustingPeriod
+  if (expirationTime <= now){
     return Expired 
   }
-
   return Active
 } 
 ```

--- a/spec/client/ics-008-wasm-client/README.md
+++ b/spec/client/ics-008-wasm-client/README.md
@@ -201,6 +201,28 @@ function verifyClientMessage(clientMsg: ClientMessage) {
 }
 ```
 
+### Retrieve client status 
+
+Return the status of the wasm client. Status can be either `Active`, `Expired`, `Unknown` or `Frozen`.
+
+```typescript
+interface StatusMsg {}
+```
+
+```typescript
+// returns the status of a client
+function Status(clientIdentifier: Identifier, clientState: clientState): Status {
+  payload = StatusMsg{}
+
+  // retrieve client identifier-prefixed store
+  clientStore = provableStore.prefixStore("clients/{clientIdentifier}")
+
+  // use underlying wasm contract to retrieve the status
+  result = callContract(clientStore, clientState, marshalJSON(payload))
+  return Status(result.status)
+} 
+```
+
 ### Misbehaviour predicate
 
 Function `checkForMisbehaviour` will check if an update contains evidence of misbehaviour. Wasm client misbehaviour checking determines whether or not two conflicting headers at the same height would have convinced the light client.

--- a/spec/core/ics-002-client-semantics/README.md
+++ b/spec/core/ics-002-client-semantics/README.md
@@ -337,6 +337,16 @@ Once misbehaviour is detected, clients SHOULD be frozen so that no future update
 A permissioned entity such as a chain governance system or trusted multi-signature MAY be allowed
 to intervene to unfreeze a frozen client & provide a new correct ClientMessage which updates the client to a valid state.
 
+#### Retrieve Client Status 
+
+Status is an opaque function defined by a client type to retrieve the current clientState. Status can be either Active, Expired, Unknown or Frozen. 
+
+The function is defined as:
+
+```typescript
+type Status = (Client) => Void
+```
+
 #### `CommitmentProof`
 
 `CommitmentProof` is an opaque data structure defined by a client type in accordance with [ICS 23](../ics-023-vector-commitments).

--- a/spec/core/ics-002-client-semantics/README.md
+++ b/spec/core/ics-002-client-semantics/README.md
@@ -337,14 +337,23 @@ Once misbehaviour is detected, clients SHOULD be frozen so that no future update
 A permissioned entity such as a chain governance system or trusted multi-signature MAY be allowed
 to intervene to unfreeze a frozen client & provide a new correct ClientMessage which updates the client to a valid state.
 
-#### Retrieve Client Status 
+#### Retrieve client status 
 
-Status is an opaque function defined by a client type to retrieve the current clientState. Status can be either Active, Expired, Unknown or Frozen. 
+Status is an opaque function defined by a client type to retrieve the current clientState. Status can be either `Active`, `Expired`, `Unknown` or `Frozen`.
+
+```typescript
+enum Status {
+  Unknown
+  Active
+  Expired
+  Froezn
+}
+```
 
 The function is defined as:
 
 ```typescript
-type Status = (Client) => Void
+type Status = (Identifier, Client) => Status
 ```
 
 #### `CommitmentProof`

--- a/spec/core/ics-002-client-semantics/README.md
+++ b/spec/core/ics-002-client-semantics/README.md
@@ -346,7 +346,7 @@ enum Status {
   Unknown
   Active
   Expired
-  Froezn
+  Frozen
 }
 ```
 

--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -710,7 +710,7 @@ function getCounterPartyHops(proof: CommitmentProof | MultihopProof, lastConnect
 // Returns the status of a client given its store.
 function Status (client: clientState) {
 
-  if (client.FrozenHeight !==0) {
+  if (client.FrozenHeight !== 0) {
 		return Frozen
 	}
   // Get latest consensus state from clientStore to check for expiry
@@ -720,7 +720,7 @@ function Status (client: clientState) {
 	}
   // Check if Expired
 	let expirationTime := consState.Timestamp + client.TrustingPeriod
-	if (expirationTime <==now){
+	if (expirationTime <== now){
     return Expired 
   }
   

--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -704,29 +704,6 @@ function getCounterPartyHops(proof: CommitmentProof | MultihopProof, lastConnect
 }
 ```
 
-##### Helper functions
-
-```typescript
-// Returns the status of a client given its store.
-function Status (client: clientState) {
-  if (client.FrozenHeight !== 0) {
-    return Frozen
-  }
-  // Get latest consensus state from clientStore to check for expiry
-  consState, err := client.latestClientHeight()
-  if err (!== nil) {
-    return Unknown
-  }
-  // Check if Expired
-  let expirationTime := consState.Timestamp + client.TrustingPeriod
-  if (expirationTime <== now){
-    return Expired 
-  }
-
-  return Active
-} 
-```
-
 #### Packet flow & handling
 
 ![Packet State Machine](packet-state-machine.png)
@@ -791,10 +768,10 @@ function sendPacket(
     connection = provableStore.get(connectionPath(channel.connectionHops[0]))
     abortTransactionUnless(connection !== null)
     
-    client = provableStore.get(clientStatePath(connection.clientIdenfier))
-    abortTransactionUnless(client !== null)
+    clientState = queryClientState(connection.clientIdenfier)
+    abortTransactionUnless(clientState !== null)
     // Checks that client is Active, abort otherwise. 
-    abortTransactionUnless(Status(client) === Active)
+    abortTransactionUnless(Status(clientState) === Active)
 
     // check if the calling module owns the sending port
     abortTransactionUnless(authenticateCapability(channelCapabilityPath(sourcePort, sourceChannel), capability))

--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -708,13 +708,13 @@ function getCounterPartyHops(proof: CommitmentProof | MultihopProof, lastConnect
 
 ```typescript
 // Returns the status of a client given its store.
-function Status (client) {
+function Status (client: clientState) {
 
   if (client.FrozenHeight !==0) {
 		return Frozen
 	}
-	// Get latest consensus state from clientStore to check for expiry
-	consState, err := getConsensusState(client.GetLatestHeight())
+  // Get latest consensus state from clientStore to check for expiry
+	consState, err := client.latestClientHeight()
 	if err (!== nil) {
 		return Unknown
 	}
@@ -792,7 +792,7 @@ function sendPacket(
     connection = provableStore.get(connectionPath(channel.connectionHops[0]))
     abortTransactionUnless(connection !== null)
     
-    client = provableStore.get(clientPath(connection.clientIdenfier))
+    client = provableStore.get(clientStatePath(connection.clientIdenfier))
     abortTransactionUnless(client !== null)
     // Checks that client is Active, abort otherwise. 
     abortTransactionUnless(Status(client) === Active)

--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -709,21 +709,20 @@ function getCounterPartyHops(proof: CommitmentProof | MultihopProof, lastConnect
 ```typescript
 // Returns the status of a client given its store.
 function Status (client: clientState) {
-
   if (client.FrozenHeight !== 0) {
-		return Frozen
-	}
+    return Frozen
+  }
   // Get latest consensus state from clientStore to check for expiry
-	consState, err := client.latestClientHeight()
-	if err (!== nil) {
-		return Unknown
-	}
+  consState, err := client.latestClientHeight()
+  if err (!== nil) {
+    return Unknown
+  }
   // Check if Expired
-	let expirationTime := consState.Timestamp + client.TrustingPeriod
-	if (expirationTime <== now){
+  let expirationTime := consState.Timestamp + client.TrustingPeriod
+  if (expirationTime <== now){
     return Expired 
   }
-  
+
   return Active
 } 
 ```


### PR DESCRIPTION
Closes: #555

Add: 
- `Status` function (in helper function section) to retrieve the client status 
- Check that client is active in `sendPacket`