### PR TITLE
Add Packet and Acknowledgement spec to ICS4 along with Commitments

### DIFF
--- a/spec/core/v2/ics-004-packet-semantics/PACKET.md
+++ b/spec/core/v2/ics-004-packet-semantics/PACKET.md
@@ -6,14 +6,16 @@ The IBC packet sends application data from a source chain to a destination chain
 
 ```typescript
 interface Packet {
-    // identifier on the source chain
-    // that source chain uses to address dest chain
-    // this functions as the sending address
-    sourceIdentifier: bytes,
-    // identifier on the dest chain
-    // that dest chain uses to address source chain
-    // this functions as the return address
-    destIdentifier: bytes,
+    // identifier for the channel on source chain
+    // channel must contain identifier of counterparty channel
+    // and the client identifier for the client on source chain
+    // that tracks dest chain
+    sourceChannel: bytes,
+    // identifier for the channel on dest chain
+    // channel must contain identifier of counterparty channel
+    // and the client identifier for the client on dest chain
+    // that tracks source chain
+    destChannel: bytes,
     // the sequence uniquely identifies this packet
     // in the stream of packets from source to dest chain
     sequence: uint64,
@@ -47,19 +49,12 @@ interface Payload {
     // the strucure expected given the version provided
     // if the encoding is not supported, receiving application
     // must be rejected with an error acknowledgement.
-    encoding: Encoding,
+    // the encoding string MUST be in MIME format
+    encoding: string,
     // appData is the opaque content sent from the source application
     // to the dest application. It will be decoded and interpreted
     // as specified by the version and encoding fields
     appData: bytes,
-}
-
-enum Encoding {
-    NO_ENCODING_SPECIFIED,
-    PROTO_3,
-    JSON,
-    RLP,
-    BCS,
 }
 ```
 

--- a/spec/core/v2/ics-004-packet-semantics/PACKET.md
+++ b/spec/core/v2/ics-004-packet-semantics/PACKET.md
@@ -1,0 +1,71 @@
+# Packet Specification
+
+## Packet V2
+
+The IBC packet sends application data from a source chain to a destination chain with a timeout that specifies when the packet is no longer valid. The packet will be committed to by the source chain as specified in the ICS-24 specification. The receiver chain will then verify the packet commitment under the ICS-24 specified packet commitment path. If the proof succeeds, the IBC handler sends the application data(s) to the relevant application(s).
+
+```typescript
+interface Packet {
+    sourceIdentifier: bytes,
+    destIdentifier: bytes,
+    sequence: uint64
+    timeout: uint64,
+    data: [Payload]
+}
+
+interface Payload {
+    sourcePort: bytes,
+    destPort: bytes,
+    version: string,
+    encoding: Encoding,
+    appData: bytes,
+}
+
+enum Encoding {
+    NO_ENCODING_SPECIFIED,
+    PROTO_3,
+    JSON,
+    RLP,
+    BCS,
+}
+```
+
+The source and destination identifiers at the top-level of the packet identifiers the chains communicating. The source identifier **must** be unique on the source chain and is a pointer to the destination chain. The destination identifier **must** be a unique identifier on the destination chain and is a pointer to the source chain. The sequence is a monotonically incrementing nonce to uniquely identify packets sent between the source and destination chain.
+
+The timeout is the UNIX timestamp in seconds that must be passed on the **destination** chain before the packet is invalid and no longer capable of being received. Note that the timeout timestamp is assessed against the destination chain's clock which may drift relative to the clocks of the sender chain or a third party observer. If a packet is received on the destination chain after the timeout timestamp has passed relative to the destination chain's clock; the packet must be rejected so that it can be safely timed out and reverted by the sender chain.
+
+In version 2 of the IBC specification, implementations **MAY** support multiple application data within the same packet. This can be represented by a list of payloads. Implementations may choose to only support a single payload per packet, in which case they can just reject incoming packets sent with multiple payloads.
+
+Each payload will include its own `Encoding` and `AppVersion` that will be sent to the application to instruct it how to decode and interpret the opaque application data. The application must be able to support the provided `Encoding` and `AppVersion` in order to process the `AppData`. If the receiving application does not support the encoding or app version, then the application **must** return an error to IBC core. If the receiving application does support the provided encoding and app version, then the application must decode the application as specified by the `Encoding` enum and then process the application as expected by the counterparty given the agreed-upon app version. Since the `Encoding` and `AppVersion` are now in each packet they can be changed on a per-packet basis and an application can simultaneously support many encodings and app versions from a counterparty. This is in stark contrast to IBC version 1 where the channel prenegotiated the channel version (which implicitly negotiates the encoding as well); so that changing the app version after channel opening is very difficult.
+
+The packet must be committed to as specified in the ICS24 specification. In order to do this we must first commit the packet data and timeout.
+
+```typescript
+func commitV2Packet(packet: Packet) {
+    timeoutBytes = LittleEndian(timeout)
+    // TODO: Decide on canonical encoding scheme
+    appBytes = encoding(payload)
+    ics24.commitPacket(packet.destinationIdentifier, timeoutBytes, appBytes)
+}
+```
+
+## Acknowledgement V2
+
+The acknowledgement in the version 2 specification is also modified to support multiple payloads in the packet that will each go to separate applications that can write their own acknowledgements. Each acknowledgment will be contained within the final packet acknowledgment in the same order that they were received in the original packet. Thus if a packet contains payloads for modules `A` and `B` in that order; the receiver will write an acknowledgment with the app acknowledgements `A` and `B` in the same order.
+
+```typescript
+interface Acknowledgement {
+    appAcknowledgement: [bytes]
+}
+```
+
+All acknowledgements must be committed to and stored under the ICS24 acknowledgment path.
+
+```typescript
+func commitV2Acknowledgment(ack: Acknowledgement) {
+    // TODO: Decide on canonical encoding scheme
+    ackBytes = encoding(ack)
+    ics24.commitAcknowledgment(ackBytes)
+}
+```
+

--- a/spec/core/v2/ics-004-packet-semantics/PACKET.md
+++ b/spec/core/v2/ics-004-packet-semantics/PACKET.md
@@ -6,18 +6,51 @@ The IBC packet sends application data from a source chain to a destination chain
 
 ```typescript
 interface Packet {
+    // identifier on the source chain
+    // that source chain uses to address dest chain
+    // this functions as the sending address
     sourceIdentifier: bytes,
+    // identifier on the dest chain
+    // that dest chain uses to address source chain
+    // this functions as the return address
     destIdentifier: bytes,
-    sequence: uint64
+    // the sequence uniquely identifies this packet
+    // in the stream of packets from source to dest chain
+    sequence: uint64,
+    // the timeout is the timestamp in seconds on the destination chain
+    // at which point the packet is no longer valid.
+    // It cannot be received on the destination chain and can
+    // be timed out on the source chain
     timeout: uint64,
+    // the data includes the messages that are intended
+    // to be sent to application(s) on the destination chain
+    // from application(s) on the source chain
+    // IBC core handlers will route the payload to the desired
+    // application using the port identifiers but the rest of the
+    // payload will be processed by the application
     data: [Payload]
 }
 
 interface Payload {
+    // sourcePort identifies the sending application on the source chain
     sourcePort: bytes,
+    // destPort identifies the receiving application on the dest chain
     destPort: bytes,
+    // version identifies the version that sending application
+    // expects destination chain to use in processing the message
+    // if dest chain does not support the version, the payload must
+    // be rejected with an error acknowledgement
     version: string,
+    // encoding allows the sending application to specify which
+    // encoding was used to encode the app data
+    // the receiving applicaton will decode the appData into
+    // the strucure expected given the version provided
+    // if the encoding is not supported, receiving application
+    // must be rejected with an error acknowledgement.
     encoding: Encoding,
+    // appData is the opaque content sent from the source application
+    // to the dest application. It will be decoded and interpreted
+    // as specified by the version and encoding fields
     appData: bytes,
 }
 
@@ -60,6 +93,12 @@ An application may not need to return an acknowledgment. In this case, it may re
 
 ```typescript
 interface Acknowledgement {
+    // Each app in the payload will have an acknowledgment in this list in the same order
+    // that they were received in the payload
+    // If an app does not need to send an acknowledgement, there must be a SENTINEL_ACKNOWLEDGEMENT
+    // in its place
+    // The app acknowledgement must be encoded in the same manner specified in the payload it received
+    // and must be created and processed in the manner expected by the version specified in the payload.
     appAcknowledgement: [bytes]
 }
 ```


### PR DESCRIPTION
Note to reviewers:

We need feedback on the packet structure and acknowledgement structure to see if it is sufficient for the use cases and platforms people have in mind but we also need feedback on the commitment structure.

The desired properties of the commitments:
- Canonical (Every compliant implementation should be able to take the same Packet/Acknowledgement and reach the exact same commitment)
- Secure (Two different packets MUST NOT create the same packet commitment)
- Implementable (The given commitment structure must be implementable by all desired target platforms: EVM, ZK, Rust, Solana)
- Cheap (The commitment structures must be feasibly cheap on desired target platforms: EVM, ZK)
- Upgradable (While this is the hardest to upgrade, by splitting each component into its own byte array and hashing them individually they can also be changed independently)

Context for current decision:

1. The first option was to hash every field to ensure that each field is clearly separated and cannot be malleated. However, with the multiple payloads (5 fields per payload) this will lead to many hashes that all then have to be hashed together. This could be inefficient and also not particularly elegant. Also by hashing even the payload fields directly, the payload is part of the hashing specification, however if the payload is simply the encoded preimage as bytes passed into the hashing function, then the encoded preimage can be changed without changing the entire hashing specification
2. Another option considered is to prefix the length of each field in order to ensure bytes from one field do not get confused with another. This seemed error prone and is effectively implementing half an encoding standard so we considered simply encoding the payload with an existing standard.
3. The third option is to encode the payload. In order to do this, we need a canonical encoding standard that is widely implementable. Unfortunately Protobuf is NOT canonical so different implementations can yield different byte arrays. The two canonical encoding standards i considered were BCS and CBOR. BCS is a blockchain specific encoding standard while CBOR is widely adopted and also implemented in Solidity. Thus i suggest canonical CBOR as an option for now however i haven't completed research on whether this is the best option. The downside is that we are now adding a particular encoding format as a core requirement of IBC v2. The benefit is that we can encode the payload and acknowledgements with this encoding format before hashing. This is simpler to implement and verify for correctness, while also being easier to upgrade. Also this requires a well maintained cbor implementation that is also canonical on the platforms we support.

From these above options, we are considering either option 1 or option 3 (with the specific canonical encoding scheme tbd). Help in determing which option is best to accomplish the desired properties above is greatly appreciated!

Dependent on #1144 
