### PR TITLE
fix: Fix incorrect validation in chanCloseFrozen function in README.md

### DIFF
--- a/spec/core/ics-004-channel-and-packet-semantics/README.md
+++ b/spec/core/ics-004-channel-and-packet-semantics/README.md
@@ -632,7 +632,7 @@ function chanCloseFrozen(
     channel = provableStore.get(channelPath(portIdentifier, channelIdentifier))
     abortTransactionUnless(channel !== null)
     hopsLength = channel.connectionHops.length
-    abortTransactionUnless(hopsLength === 1)
+    abortTransactionUnless(hopsLength > 1)
     abortTransactionUnless(channel.state !== CLOSED)
     connection = provableStore.get(connectionPath(channel.connectionHops[0]))
     abortTransactionUnless(connection !== null)


### PR DESCRIPTION
I noticed an issue in the `chanCloseFrozen` function where the validation `abortTransactionUnless(hopsLength === 1)` doesn't align with the intended logic.

Since this function is designed to handle multi-hop connections, the check should ensure that `connectionHops` length is greater than 1, not equal to 1.

This change ensures the function works correctly for its intended use case.  
