### PR TITLE
Fix incorrect TypeScript syntax in upgrade callback functions

### DIFF
--- a/spec/core/ics-026-routing-module/UPGRADES.md
+++ b/spec/core/ics-026-routing-module/UPGRADES.md
@@ -51,10 +51,10 @@ function onChanUpgradeInit(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
   proposedOrdering: ChannelOrder,
-  proposedConnectionHops: [Identifier],
-  proposedVersion: string) => (version: string, err: Error) {
+  proposedConnectionHops: Identifier[],
+  proposedVersion: string): [string, Error | null] {
     // defined by the module
-} (version: string)
+}
 ```
 
 ### **OnChanUpgradeTry**
@@ -71,10 +71,10 @@ function onChanUpgradeTry(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
   proposedOrdering: ChannelOrder,
-  proposedConnectionHops: [Identifier],
-  proposedVersion: string) => (version: string, err: Error) {
+  proposedConnectionHops: Identifier[],
+  proposedVersion: string): [string, Error | null] {
     // defined by the module
-} (version: string)
+}
 ```
 
 ### **OnChanUpgradeAck**
@@ -88,7 +88,7 @@ is unsupported. If an error is returned by the callback, core IBC will abort the
 function onChanUpgradeAck(
   portIdentifier: Identifier,
   channelIdentifier: Identifier,
-  counterpartyVersion: string) => Error {
+  counterpartyVersion: string): Error | null {
     // defined by the module
 }
 ```


### PR DESCRIPTION
- Fixed incorrect array syntax: `[Identifier]` → `Identifier[]`

- Replaced incorrect arrow (`=>`) syntax for return types:
  - `=> (version: string, err: Error)` → `: [string, Error | null]`
  - `=> Error` → `: Error | null`

- Removed unnecessary `(version: string)` at the end of function definitions

