### PR TITLE
fix: specify validator set choice in CCV consumer chain initialization

### DIFF
--- a/spec/app/ics-028-cross-chain-validation/methods.md
+++ b/spec/app/ics-028-cross-chain-validation/methods.md
@@ -447,8 +447,10 @@ function CreateConsumerClient(p: ConsumerAdditionProposal) {
   // the validator set is the same as the validator set 
   // from own consensus state at current height
   // 
-  // TODO: ownConsensusState.validatorSet VS consensusState.nextValidatorsHash
-  //       specify which validator set is used as the initial val set
+  // Using ownConsensusState.validatorSet as the initial validator set is preferred
+  // over consensusState.nextValidatorsHash because it provides the full validator set
+  // information directly rather than just a hash, ensuring complete validator data
+  // is available for the consumer chain initialization.
   ownConsensusState = getConsensusState(getCurrentHeight())
   initialValSet = ownConsensusState.validatorSet
 


### PR DESCRIPTION
Clarifies which validator set should be used during consumer chain initialization in the Cross-Chain Validation module. 