### PR TITLE
ICS20: Correction to the denom in the sequence diagram

### DIFF
--- a/spec/app/ics-020-fungible-token-transfer/README.md
+++ b/spec/app/ics-020-fungible-token-transfer/README.md
@@ -79,7 +79,7 @@ sequenceDiagram
     chain C->>chain B: Send transfer packet with vouchers ("transfer/ChannelToB/transfer/ChannelToA/denom")
     chain B->>chain B: Unlock (unescrow) vouchers ("transfer/ChannelToA/denom")
     Note over chain B,chain A: B is sink zone: B -> A
-    chain B->>chain B: Burn vouchers ("transfer/ChannelToB/transfer/ChannelToA/denom")
+    chain B->>chain B: Burn vouchers ("transfer/channelToA/denom")
     chain B->>chain A: Send transfer packet with vouchers ("transfer/ChannelToB/transfer/ChannelToA/denom")
     chain A->>chain A: Unlock (unescrow) vouchers ("transfer/ChannelToA/denom")
 ```

--- a/spec/app/ics-020-fungible-token-transfer/README.md
+++ b/spec/app/ics-020-fungible-token-transfer/README.md
@@ -80,8 +80,8 @@ sequenceDiagram
     chain B->>chain B: Unlock (unescrow) vouchers ("transfer/ChannelToA/denom")
     Note over chain B,chain A: B is sink zone: B -> A
     chain B->>chain B: Burn vouchers ("transfer/channelToA/denom")
-    chain B->>chain A: Send transfer packet with vouchers ("transfer/ChannelToB/transfer/ChannelToA/denom")
-    chain A->>chain A: Unlock (unescrow) vouchers ("transfer/ChannelToA/denom")
+    chain B->>chain A: Send transfer packet with vouchers ("transfer/ChannelToA/denom")
+    chain A->>chain A: Unlock (unescrow) vouchers ("denom")
 ```
 
 The acknowledgement data type describes whether the transfer succeeded or failed, and the reason for failure (if any).

--- a/spec/app/ics-020-fungible-token-transfer/README.md
+++ b/spec/app/ics-020-fungible-token-transfer/README.md
@@ -79,9 +79,9 @@ sequenceDiagram
     chain C->>chain B: Send transfer packet with vouchers ("transfer/ChannelToB/transfer/ChannelToA/denom")
     chain B->>chain B: Unlock (unescrow) vouchers ("transfer/ChannelToA/denom")
     Note over chain B,chain A: B is sink zone: B -> A
-    chain B->>chain B: Burn vouchers ("transfer/channelToA/denom")
+    chain B->>chain B: Burn vouchers ("transfer/ChannelToA/denom")
     chain B->>chain A: Send transfer packet with vouchers ("transfer/ChannelToA/denom")
-    chain A->>chain A: Unlock (unescrow) vouchers ("denom")
+    chain A->>chain A: Unlock (unescrow) tokens ("denom")
 ```
 
 The acknowledgement data type describes whether the transfer succeeded or failed, and the reason for failure (if any).


### PR DESCRIPTION
This PR addresses one imprecision in ICS20 README that may cause confusion in otherwise very helpful sequence diagram example.

In the diagram illustrating multi-chain token transfer, there is a mistake in the denoms (in the last transaction):
 - `B` should be burning `transfer/ChannelToA/denom` (instead of `transfer/ChannelToB/transfer/ChannelToA/denom`)
 - `B` should be sending to `A` `transfer/ChannelToA/denom` (instead of `transfer/ChannelToB/transfer/ChannelToA/denom`)
 - `A` should be unlocking `denom` (instead of `transfer/channelToA/denom`)