### PR TITLE
fix(ics-020): improve string prefix check efficiency

### DIFF
--- a/spec/app/ics-020-fungible-token-transfer/README.md
+++ b/spec/app/ics-020-fungible-token-transfer/README.md
@@ -255,7 +255,7 @@ function sendFungibleTokens(
 ): uint64 {
     prefix = "{sourcePort}/{sourceChannel}/"
     // we are the source if the denomination is not prefixed
-    source = denomination.slice(0, len(prefix)) !== prefix
+    source = !denomination.startsWith(prefix)
     if source {
       // determine escrow account
       escrowAccount = channelEscrowAddresses[sourceChannel]


### PR DESCRIPTION
Replace inefficient string prefix checking with startsWith() method for better performance and readability in sendFungibleTokens function