### PR TITLE
fix: use getChannel instead of getConnection for channel queries

### DIFF
--- a/spec/relayer/ics-018-relayer-algorithms/README.md
+++ b/spec/relayer/ics-018-relayer-algorithms/README.md
@@ -177,7 +177,7 @@ function pendingDatagrams(chain: Chain, counterparty: Chain): List<Set<Datagram>
   // - Determine if any packets, acknowledgements, or timeouts need to be relayed
   channels = chain.getChannelsUsingConnections(connections)
   for (const localEnd of channels) {
-    remoteEnd = counterparty.getConnection(localEnd.counterpartyIdentifier)
+    remoteEnd = counterparty.getChannel(localEnd.counterpartyPortIdentifier, localEnd.counterpartyChannelIdentifier)
     // Deal with handshakes in progress
     if (localEnd.state === INIT && remoteEnd === null)
       // Handshake has started locally (1 step done), relay `chanOpenTry` to the remote end


### PR DESCRIPTION
### Motivation
The channel handshake logic in pendingDatagrams incorrectly uses getConnection() with a non-existent counterpartyIdentifier field when querying channels. This breaks the example code since ChannelEnd doesn't have counterpartyIdentifier—it uses counterpartyPortIdentifier and counterpartyChannelIdentifier.
### Solution
Replace counterparty.getConnection(localEnd.counterpartyIdentifier) with counterparty.getChannel(localEnd.counterpartyPortIdentifier, localEnd.counterpartyChannelIdentifier) to correctly query the counterparty channel end using the proper method and fields from the ChannelEnd structure.