### PR TITLE
chore: add foundations team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+** @cosmos/foundations-team


### PR DESCRIPTION
## Summary

- Adds `@cosmos/foundations-team` as a code owner to ensure the foundations team is automatically assigned as reviewers on PRs.

## Linked issue
ITS-1231