### PR TITLE
[E2E harness 1/8] Restrict config environment expansion

### DIFF
--- a/link/internal/config/config.go
+++ b/link/internal/config/config.go
@@ -106,8 +106,8 @@ func DefaultConfig() Config {
 	}
 }
 
-// LoadFromFile loads Config from file with optional validation.
-// Note: supports ENV variables expansion!
+// LoadFromFile loads Config from file with optional validation. Database URLs may carry explicit
+// ${NAME} environment references; other dollar-sign forms are literals.
 func LoadFromFile(path string, validate, restrictUnknownFields bool) (Config, error) {
 	config := DefaultConfig()
 
@@ -116,17 +116,18 @@ func LoadFromFile(path string, validate, restrictUnknownFields bool) (Config, er
 		return Config{}, err
 	}
 
-	// substitute ENV variables
-	expanded := os.ExpandEnv(string(bz))
-
 	opts := []yaml.DecodeOption{}
 	if restrictUnknownFields {
 		opts = append(opts, yaml.DisallowUnknownField())
 	}
 
-	err = yaml.UnmarshalWithOptions([]byte(expanded), &config, opts...)
+	err = yaml.UnmarshalWithOptions(bz, &config, opts...)
 	if err != nil {
 		return Config{}, err
+	}
+	config.DB.URL, err = ExpandEnvRefs(config.DB.URL)
+	if err != nil {
+		return Config{}, fmt.Errorf("expand .db.url: %w", err)
 	}
 
 	if validate {

--- a/link/internal/config/config_test.go
+++ b/link/internal/config/config_test.go
@@ -83,19 +83,43 @@ db:
 		})
 
 		t.Run("envSubstitution", func(t *testing.T) {
-			// ARRANGE
+			t.Setenv("DATABASE_NAME", "ibc-test")
+			path := writeTestConfig(t, `
+db:
+  type: postgres
+  url: postgres://localhost/${DATABASE_NAME}
+`)
+
+			config, err := LoadFromFile(path, true, true)
+
+			require.NoError(t, err)
+			assert.Equal(t, "postgres://localhost/ibc-test", config.DB.URL)
+		})
+
+		t.Run("expansionIsTyped", func(t *testing.T) {
 			t.Setenv("SERVER_PORT", "9091")
 			path := writeTestConfig(t, `
 server:
   listenAddr: 127.0.0.1:${SERVER_PORT}
 `)
 
-			// ACT
-			config, err := LoadFromFile(path, true, true)
+			config, err := LoadFromFile(path, false, true)
 
-			// ASSERT
 			require.NoError(t, err)
-			assert.Equal(t, "127.0.0.1:9091", config.Server.ListenAddress)
+			assert.Equal(t, "127.0.0.1:${SERVER_PORT}", config.Server.ListenAddress)
+		})
+
+		t.Run("missingEnvFails", func(t *testing.T) {
+			path := writeTestConfig(t, `
+db:
+  type: postgres
+  url: postgres://localhost/${IBC_LINK_TEST_MISSING_DATABASE}
+`)
+
+			_, err := LoadFromFile(path, true, true)
+
+			require.ErrorContains(t, err, "expand .db.url")
+			require.ErrorContains(t, err, "environment variable IBC_LINK_TEST_MISSING_DATABASE is not set")
 		})
 
 		t.Run("invalidYaml", func(t *testing.T) {

--- a/link/internal/config/env.go
+++ b/link/internal/config/env.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+)
+
+var envRef = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
+
+// ExpandEnvRefs resolves explicit ${NAME} references. Other dollar-sign forms are literals, and a
+// reference to an unset variable is a configuration error.
+func ExpandEnvRefs(value string) (string, error) {
+	var expandErr error
+	expanded := envRef.ReplaceAllStringFunc(value, func(ref string) string {
+		name := ref[2 : len(ref)-1]
+		resolved, ok := os.LookupEnv(name)
+		if !ok && expandErr == nil {
+			expandErr = fmt.Errorf("environment variable %s is not set", name)
+		}
+		return resolved
+	})
+	if expandErr != nil {
+		return "", expandErr
+	}
+	return expanded, nil
+}

--- a/link/internal/config/env_test.go
+++ b/link/internal/config/env_test.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandEnvRefs(t *testing.T) {
+	t.Setenv("IBC_LINK_TEST_TOKEN", "secret")
+	t.Setenv("IBC_LINK_TEST_DOLLARS", "$UNCHANGED")
+	t.Setenv("IBC_LINK_TEST_EMPTY", "")
+
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "explicit reference", value: "before-${IBC_LINK_TEST_TOKEN}-after", want: "before-secret-after"},
+		{name: "double dollar is literal", value: "$$", want: "$$"},
+		{name: "url dollar is literal", value: "http://host/?token=$X", want: "http://host/?token=$X"},
+		{name: "invalid name is literal", value: "${1INVALID}", want: "${1INVALID}"},
+		{name: "replacement is not recursive", value: "${IBC_LINK_TEST_DOLLARS}", want: "$UNCHANGED"},
+		{name: "set empty value", value: "${IBC_LINK_TEST_EMPTY}", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ExpandEnvRefs(tc.value)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+
+	_, err := ExpandEnvRefs("${IBC_LINK_TEST_MISSING_VALUE}")
+	require.EqualError(t, err, "environment variable IBC_LINK_TEST_MISSING_VALUE is not set")
+}

--- a/link/internal/config/ibc.yml
+++ b/link/internal/config/ibc.yml
@@ -1,13 +1,12 @@
 # sample config file
 server:
   listenAddr: 0.0.0.0:3000
-  # listenAddr: 127.0.0.1:${SERVER_PORT}  # supports for env vars expansion
 
 db:
   type: sqlite
   url: ibc.db
   # type: postgres
-  # url: postgres://user:pass@localhost:5432/ibc
+  # url: postgres://user:${DATABASE_PASSWORD}@localhost:5432/ibc
 
 # signers define signing backends referenced by attestations
 #


### PR DESCRIPTION
Restricts environment expansion to explicit `${NAME}` references in `db.url`. Other fields and dollar-sign forms remain literal, and unset references now return an error.

Stack: 1/8.

Validation: `go test ./internal/config`.