### PR TITLE
add relayer config

### DIFF
--- a/link/internal/config/config.go
+++ b/link/internal/config/config.go
@@ -132,7 +132,7 @@ func DefaultConfig() Config {
 		},
 		Chains: []ChainConfig{},
 		Relayer: RelayerConfig{
-			ChainOverrides: []ChainOverride{},
+			ChainOverrides: []RelayerChainOverride{},
 		},
 		Attestor: AttestorConfig{
 			Attestations: []AttestationConfig{},

--- a/link/internal/config/config.go
+++ b/link/internal/config/config.go
@@ -102,13 +102,21 @@ const (
 // ChainConfig chain information shared by the attestor and relayer.
 type ChainConfig struct {
 	ChainID string          `yaml:"chainId"`
-	Type    ChainType       `yaml:"type"`
-	RPC     string          `yaml:"rpc"`
 	EVM     *EVMChainConfig `yaml:"evm,omitempty"`
+}
+
+// Type returns the chain type implied by the configured settings.
+func (c ChainConfig) Type() ChainType {
+	if c.EVM != nil {
+		return ChainTypeEVM
+	}
+
+	return ""
 }
 
 // EVMChainConfig EVM-specific chain details.
 type EVMChainConfig struct {
+	RPC         string `yaml:"rpc"`
 	ICS26Router string `yaml:"ics26Router"`
 }
 
@@ -259,19 +267,12 @@ func (c ChainConfig) Validate() error {
 	switch {
 	case c.ChainID == "":
 		return errors.New(".chainId required")
-	case c.Type != ChainTypeEVM:
-		return errors.Errorf(".type unknown chain type: %q", c.Type)
-	case c.RPC == "":
-		return errors.New(".rpc required")
-	}
-
-	if c.Type == ChainTypeEVM {
-		switch {
-		case c.EVM == nil:
-			return errors.Errorf(".evm required for %s chains", ChainTypeEVM)
-		case c.EVM.ICS26Router == "":
-			return errors.New(".evm.ics26Router required")
-		}
+	case c.Type() != ChainTypeEVM:
+		return errors.Errorf("unknown chain type (only %s chains are supported)", ChainTypeEVM)
+	case c.EVM.RPC == "":
+		return errors.New(".evm.rpc required")
+	case c.EVM.ICS26Router == "":
+		return errors.New(".evm.ics26Router required")
 	}
 
 	return nil

--- a/link/internal/config/config.go
+++ b/link/internal/config/config.go
@@ -33,6 +33,8 @@ const sqliteInMemory = ":memory:"
 type Config struct {
 	Server   ServerConfig   `yaml:"server"`
 	DB       DBConfig       `yaml:"db"`
+	Chains   []ChainConfig  `yaml:"chains"`
+	Relayer  RelayerConfig  `yaml:"relayer"`
 	Attestor AttestorConfig `yaml:"attestor"`
 	Signers  Signers        `yaml:"signers"`
 }
@@ -89,6 +91,27 @@ type AttestationConfig struct {
 	FinalityOffset int64  `yaml:"-"`
 }
 
+// ChainType the execution environment of a chain.
+type ChainType string
+
+// Chain types
+const (
+	ChainTypeEVM ChainType = "evm"
+)
+
+// ChainConfig chain information shared by the attestor and relayer.
+type ChainConfig struct {
+	ChainID string          `yaml:"chainId"`
+	Type    ChainType       `yaml:"type"`
+	RPC     string          `yaml:"rpc"`
+	EVM     *EVMChainConfig `yaml:"evm,omitempty"`
+}
+
+// EVMChainConfig EVM-specific chain details.
+type EVMChainConfig struct {
+	ICS26Router string `yaml:"ics26Router"`
+}
+
 // DefaultConfig sample config using default values and Sqlite.
 func DefaultConfig() Config {
 	return Config{
@@ -98,6 +121,10 @@ func DefaultConfig() Config {
 		DB: DBConfig{
 			Type: DBTypeSQLite,
 			URL:  "ibc.db",
+		},
+		Chains: []ChainConfig{},
+		Relayer: RelayerConfig{
+			Chains: []RelayerChainConfig{},
 		},
 		Attestor: AttestorConfig{
 			Attestations: []AttestationConfig{},
@@ -147,6 +174,26 @@ func (c Config) Validate() error {
 		return errors.Wrap(err, ".db")
 	}
 
+	chainIDs := make(map[string]struct{})
+	for _, chain := range c.Chains {
+		if err := chain.Validate(); err != nil {
+			return errors.Wrapf(err, ".chains[%s]", chain.ChainID)
+		}
+
+		if _, ok := chainIDs[chain.ChainID]; ok {
+			return errors.Wrapf(errors.Errorf("duplicate chainId: %q", chain.ChainID), ".chains")
+		}
+		chainIDs[chain.ChainID] = struct{}{}
+	}
+
+	if err := c.validateChainReferences(); err != nil {
+		return errors.Wrap(err, ".relayer")
+	}
+
+	if err := c.Relayer.Validate(); err != nil {
+		return errors.Wrap(err, ".relayer")
+	}
+
 	if err := c.Attestor.Validate(); err != nil {
 		return errors.Wrap(err, ".attestor")
 	}
@@ -171,6 +218,59 @@ func (c Config) crossValidate() error {
 				i,
 				attestation.Signer,
 			)
+		}
+	}
+
+	return nil
+}
+
+// validateChainReferences ensures chains referenced by the relayer config are
+// declared in the top-level chains block.
+func (c Config) validateChainReferences() error {
+	for _, chain := range c.Relayer.Chains {
+		if _, ok := c.Chain(chain.ChainID); chain.ChainID != "" && !ok {
+			return errors.Errorf(".chains[%s] chainId not declared in top-level chains", chain.ChainID)
+		}
+	}
+
+	for _, client := range c.Relayer.Clients {
+		if _, ok := c.Chain(client.ChainID); client.ChainID != "" && !ok {
+			return errors.Errorf(
+				".clients[%s] chainId %q not declared in top-level chains",
+				client.ClientID, client.ChainID,
+			)
+		}
+	}
+
+	return nil
+}
+
+func (c Config) Chain(chainID string) (ChainConfig, bool) {
+	for _, chain := range c.Chains {
+		if chain.ChainID == chainID {
+			return chain, true
+		}
+	}
+
+	return ChainConfig{}, false
+}
+
+func (c ChainConfig) Validate() error {
+	switch {
+	case c.ChainID == "":
+		return errors.New(".chainId required")
+	case c.Type != ChainTypeEVM:
+		return errors.Errorf(".type unknown chain type: %q", c.Type)
+	case c.RPC == "":
+		return errors.New(".rpc required")
+	}
+
+	if c.Type == ChainTypeEVM {
+		switch {
+		case c.EVM == nil:
+			return errors.Errorf(".evm required for %s chains", ChainTypeEVM)
+		case c.EVM.ICS26Router == "":
+			return errors.New(".evm.ics26Router required")
 		}
 	}
 

--- a/link/internal/config/config.go
+++ b/link/internal/config/config.go
@@ -260,15 +260,17 @@ func (c Config) Chain(chainID string) (ChainConfig, bool) {
 }
 
 func (c ChainConfig) Validate() error {
-	switch {
-	case c.ChainID == "":
+	if c.ChainID == "" {
 		return errors.New(".chainId required")
-	case c.Type() != ChainTypeEVM:
-		return errors.Errorf("unknown chain type (only %s chains are supported)", ChainTypeEVM)
-	case c.EVM.RPC == "":
-		return errors.New(".evm.rpc required")
-	case c.EVM.ICS26Router == "":
-		return errors.New(".evm.ics26Router required")
+	}
+
+	if c.Type() == ChainTypeEVM {
+		switch {
+		case c.EVM.RPC == "":
+			return errors.New(".evm.rpc required")
+		case c.EVM.ICS26Router == "":
+			return errors.New(".evm.ics26Router required")
+		}
 	}
 
 	return nil

--- a/link/internal/config/config.go
+++ b/link/internal/config/config.go
@@ -132,7 +132,7 @@ func DefaultConfig() Config {
 		},
 		Chains: []ChainConfig{},
 		Relayer: RelayerConfig{
-			Chains: []RelayerChainConfig{},
+			ChainOverrides: []ChainOverride{},
 		},
 		Attestor: AttestorConfig{
 			Attestations: []AttestationConfig{},
@@ -231,9 +231,9 @@ func (c Config) crossValidate() error {
 // validateChainReferences ensures chains referenced by the relayer config are
 // declared in the top-level chains block.
 func (c Config) validateChainReferences() error {
-	for _, chain := range c.Relayer.Chains {
+	for _, chain := range c.Relayer.ChainOverrides {
 		if _, ok := c.Chain(chain.ChainID); chain.ChainID != "" && !ok {
-			return errors.Errorf(".chains[%s] chainId not declared in top-level chains", chain.ChainID)
+			return errors.Errorf(".chainOverrides[%s] chainId not declared in top-level chains", chain.ChainID)
 		}
 	}
 

--- a/link/internal/config/config.go
+++ b/link/internal/config/config.go
@@ -194,10 +194,6 @@ func (c Config) Validate() error {
 		chainIDs[chain.ChainID] = struct{}{}
 	}
 
-	if err := c.validateChainReferences(); err != nil {
-		return errors.Wrap(err, ".relayer")
-	}
-
 	if err := c.Relayer.Validate(); err != nil {
 		return errors.Wrap(err, ".relayer")
 	}
@@ -229,7 +225,7 @@ func (c Config) crossValidate() error {
 		}
 	}
 
-	return nil
+	return c.validateChainReferences()
 }
 
 // validateChainReferences ensures chains referenced by the relayer config are

--- a/link/internal/config/ibc.yml
+++ b/link/internal/config/ibc.yml
@@ -23,7 +23,7 @@ chains:
 
 relayer:
   # relay specific chain settings
-  chains:
+  chainOverrides:
     - chainId: "1"
       txSubmissionDelay: 5s
       packetBatchSize: 50

--- a/link/internal/config/ibc.yml
+++ b/link/internal/config/ibc.yml
@@ -7,7 +7,67 @@ db:
   type: sqlite
   url: ibc.db
   # type: postgres
-  # url: postgres://user:pass@localhost:5432/ibc
+  # url: postgres://user:password@host:port/dbname
+
+# chains declares chain information shared by the attestor and relayer;
+# referenced by other blocks via chainId
+chains:
+  - chainId: "1"
+    type: evm
+    rpc: https://ethereum-rpc.example.com
+    evm:
+      ics26Router: "0x0000000000000000000000000000000000000000"
+  - chainId: "8453"
+    type: evm
+    rpc: https://base-rpc.example.com
+    evm:
+      ics26Router: "0x0000000000000000000000000000000000000000"
+
+relayer:
+  # relay specific chain settings
+  chains:
+    - chainId: "1"
+      txSubmissionDelay: 5s
+      packetBatchSize: 50
+
+  # attestors the relayer queries for packet and state attestations; they
+  # point to a configured client
+  attestors:
+    - name: "attestor-base"
+      type: remote
+      grpc: attestor.example.com:3000
+      client: "eth-to-base"
+    - name: "attestor-ethereum"
+      type: remote
+      grpc: attestor.example.com:3000
+      client: "base-to-eth"
+
+  # a client and its counterparty both need to be configured
+  clients:
+    - alias: "eth-to-base"
+      clientId: "base-0"
+      chainId: "1"
+      counterpartyChainId: "8453"
+      counterpartyClientId: "ethereum-0"
+      type: "attestation"
+      attestorSet:
+        counterpartyChainFinalityOffset: 1
+        threshold: 1
+    - alias: "base-to-eth"
+      clientId: "ethereum-0"
+      chainId: "8453"
+      counterpartyChainId: "1"
+      counterpartyClientId: "base-0"
+      type: "attestation"
+      attestorSet:
+        counterpartyChainFinalityOffset: 1
+        threshold: 1
+
+  # packets sent from the source client are relayed through the entire packet
+  # lifecycle: recv, ack, timeout
+  routesToRelay:
+    - sourceClient: "eth-to-base"
+    - sourceClient: "base-to-eth"
 
 # signers define signing backends referenced by attestations
 #

--- a/link/internal/config/ibc.yml
+++ b/link/internal/config/ibc.yml
@@ -13,14 +13,12 @@ db:
 # referenced by other blocks via chainId
 chains:
   - chainId: "1"
-    type: evm
-    rpc: https://ethereum-rpc.example.com
     evm:
+      rpc: https://ethereum-rpc.example.com
       ics26Router: "0x0000000000000000000000000000000000000000"
   - chainId: "8453"
-    type: evm
-    rpc: https://base-rpc.example.com
     evm:
+      rpc: https://base-rpc.example.com
       ics26Router: "0x0000000000000000000000000000000000000000"
 
 relayer:

--- a/link/internal/config/ibc.yml
+++ b/link/internal/config/ibc.yml
@@ -28,18 +28,6 @@ relayer:
       txSubmissionDelay: 5s
       packetBatchSize: 50
 
-  # attestors the relayer queries for packet and state attestations; they
-  # point to a configured client
-  attestors:
-    - name: "attestor-base"
-      type: remote
-      grpc: attestor.example.com:3000
-      client: "eth-to-base"
-    - name: "attestor-ethereum"
-      type: remote
-      grpc: attestor.example.com:3000
-      client: "base-to-eth"
-
   # a client and its counterparty both need to be configured
   clients:
     - alias: "eth-to-base"
@@ -51,6 +39,10 @@ relayer:
       attestorSet:
         counterpartyChainFinalityOffset: 1
         threshold: 1
+        attestors:
+          - name: "attestor-base"
+            type: remote
+            grpc: attestor.example.com:3000
     - alias: "base-to-eth"
       clientId: "ethereum-0"
       chainId: "8453"
@@ -60,6 +52,10 @@ relayer:
       attestorSet:
         counterpartyChainFinalityOffset: 1
         threshold: 1
+        attestors:
+          - name: "attestor-ethereum"
+            type: remote
+            grpc: attestor.example.com:3000
 
   # packets sent from the source client are relayed through the entire packet
   # lifecycle: recv, ack, timeout

--- a/link/internal/config/relayer.go
+++ b/link/internal/config/relayer.go
@@ -27,7 +27,6 @@ const (
 type RelayerConfig struct {
 	ChainOverrides []RelayerChainOverride `yaml:"chainOverrides"`
 	Clients        []ClientConfig         `yaml:"clients"`
-	Attestors      []AttestorEntry        `yaml:"attestors"`
 	Routes         []RouteConfig          `yaml:"routesToRelay"`
 }
 
@@ -48,7 +47,7 @@ type RelayerEVMConfig struct {
 
 // ClientConfig a light client on a chain.
 type ClientConfig struct {
-	// Alias unique config-level handle referenced by attestors and routes.
+	// Alias unique config-level handle referenced by routes.
 	Alias                string             `yaml:"alias"`
 	ClientID             string             `yaml:"clientId"`
 	ChainID              string             `yaml:"chainId"`
@@ -60,16 +59,16 @@ type ClientConfig struct {
 
 // AttestorSetConfig attestation policy for a client.
 type AttestorSetConfig struct {
-	CounterpartyChainFinalityOffset uint64 `yaml:"counterpartyChainFinalityOffset"`
-	Threshold                       int    `yaml:"threshold"`
+	CounterpartyChainFinalityOffset uint64          `yaml:"counterpartyChainFinalityOffset"`
+	Threshold                       int             `yaml:"threshold"`
+	Attestors                       []AttestorEntry `yaml:"attestors"`
 }
 
 // AttestorEntry an attestor the relayer queries for packet and state attestations.
 type AttestorEntry struct {
-	Name   string       `yaml:"name"`
-	Type   AttestorType `yaml:"type"`
-	GRPC   string       `yaml:"grpc,omitempty"`
-	Client string       `yaml:"client"`
+	Name string       `yaml:"name"`
+	Type AttestorType `yaml:"type"`
+	GRPC string       `yaml:"grpc,omitempty"`
 }
 
 // RouteConfig packets sent from the source client are relayed through the
@@ -85,19 +84,6 @@ type AutoRelayConfig struct {
 	// Lookback the number of blocks the relayer looks back from the latest
 	// block to check for packets to relay.
 	Lookback uint64 `yaml:"lookback,omitempty"`
-}
-
-// ClientAttestors returns the attestors associated with a client.
-func (c RelayerConfig) ClientAttestors(clientAlias string) []AttestorEntry {
-	var attestors []AttestorEntry
-
-	for _, attestor := range c.Attestors {
-		if attestor.Client == clientAlias {
-			attestors = append(attestors, attestor)
-		}
-	}
-
-	return attestors
 }
 
 // ClientByAlias returns the client config for the given alias.
@@ -131,10 +117,6 @@ func (c RelayerConfig) Validate() error {
 		return err
 	}
 
-	if err := c.validateAttestors(); err != nil {
-		return err
-	}
-
 	return c.validateRoutes()
 }
 
@@ -150,49 +132,6 @@ func (c RelayerConfig) validateChainOverrides() error {
 			return errors.Errorf(".chainOverrides duplicate chainId: %q", chain.ChainID)
 		}
 		chainIDs[chain.ChainID] = struct{}{}
-	}
-
-	return nil
-}
-
-func (c RelayerConfig) validateAttestors() error {
-	seen := make(map[AttestorEntry]struct{})
-
-	for i, attestor := range c.Attestors {
-		if err := attestor.Validate(); err != nil {
-			return errors.Wrapf(err, ".attestors[%d]", i)
-		}
-
-		client, ok := c.ClientByAlias(attestor.Client)
-		if !ok {
-			return errors.Errorf(".attestors[%s] references unknown client %q", attestor.Name, attestor.Client)
-		}
-
-		if client.Type != ClientTypeAttestation {
-			return errors.Errorf(
-				".attestors[%s] client %q must have type %q",
-				attestor.Name, attestor.Client, ClientTypeAttestation,
-			)
-		}
-
-		if _, ok := seen[attestor]; ok {
-			return errors.Errorf(".attestors duplicate entry: name %q client %q", attestor.Name, attestor.Client)
-		}
-		seen[attestor] = struct{}{}
-	}
-
-	for _, client := range c.Clients {
-		if client.Type != ClientTypeAttestation {
-			continue
-		}
-
-		count := len(c.ClientAttestors(client.Alias))
-		if client.AttestorSet.Threshold > count {
-			return errors.Errorf(
-				".clients[%s].attestorSet threshold %d exceeds number of attestors %d",
-				client.Alias, client.AttestorSet.Threshold, count,
-			)
-		}
 	}
 
 	return nil
@@ -335,6 +274,23 @@ func (c AttestorSetConfig) Validate() error {
 		return errors.New(".threshold must be at least 1")
 	}
 
+	if c.Threshold > len(c.Attestors) {
+		return errors.Errorf(".threshold %d exceeds number of attestors %d", c.Threshold, len(c.Attestors))
+	}
+
+	seen := make(map[AttestorEntry]struct{})
+
+	for i, attestor := range c.Attestors {
+		if err := attestor.Validate(); err != nil {
+			return errors.Wrapf(err, ".attestors[%d]", i)
+		}
+
+		if _, ok := seen[attestor]; ok {
+			return errors.Errorf(".attestors duplicate entry: name %q", attestor.Name)
+		}
+		seen[attestor] = struct{}{}
+	}
+
 	return nil
 }
 
@@ -342,8 +298,6 @@ func (c AttestorEntry) Validate() error {
 	switch {
 	case c.Name == "":
 		return errors.New(".name required")
-	case c.Client == "":
-		return errors.New(".client required")
 	case c.Type != AttestorTypeRemote && c.Type != AttestorTypeLocal:
 		return errors.Errorf(".type unknown attestor type: %q", c.Type)
 	case c.Type == AttestorTypeRemote && c.GRPC == "":

--- a/link/internal/config/relayer.go
+++ b/link/internal/config/relayer.go
@@ -26,14 +26,14 @@ const (
 
 // RelayerConfig the relayer block of the config.
 type RelayerConfig struct {
-	Chains    []RelayerChainConfig `yaml:"chains"`
-	Clients   []ClientConfig       `yaml:"clients"`
-	Attestors []AttestorEntry      `yaml:"attestors"`
-	Routes    []RouteConfig        `yaml:"routesToRelay"`
+	ChainOverrides []ChainOverride `yaml:"chainOverrides"`
+	Clients        []ClientConfig  `yaml:"clients"`
+	Attestors      []AttestorEntry `yaml:"attestors"`
+	Routes         []RouteConfig   `yaml:"routesToRelay"`
 }
 
-// RelayerChainConfig relay settings for one chain.
-type RelayerChainConfig struct {
+// ChainOverride relay settings for one chain.
+type ChainOverride struct {
 	ChainID            string              `yaml:"chainId"`
 	EVM                *RelayerEVMConfig   `yaml:"evm,omitempty"`
 	GasAlertThresholds *GasAlertThresholds `yaml:"gasAlertThresholds,omitempty"`
@@ -131,7 +131,7 @@ func (c RelayerConfig) Client(chainID, clientID string) (ClientConfig, bool) {
 
 // Validate validates the relayer config. Allows empty blocks.
 func (c RelayerConfig) Validate() error {
-	if err := c.validateChains(); err != nil {
+	if err := c.validateChainOverrides(); err != nil {
 		return err
 	}
 
@@ -146,16 +146,16 @@ func (c RelayerConfig) Validate() error {
 	return c.validateRoutes()
 }
 
-func (c RelayerConfig) validateChains() error {
+func (c RelayerConfig) validateChainOverrides() error {
 	chainIDs := make(map[string]struct{})
 
-	for _, chain := range c.Chains {
+	for _, chain := range c.ChainOverrides {
 		if err := chain.Validate(); err != nil {
-			return errors.Wrapf(err, ".chains[%s]", chain.ChainID)
+			return errors.Wrapf(err, ".chainOverrides[%s]", chain.ChainID)
 		}
 
 		if _, ok := chainIDs[chain.ChainID]; ok {
-			return errors.Errorf(".chains duplicate chainId: %q", chain.ChainID)
+			return errors.Errorf(".chainOverrides duplicate chainId: %q", chain.ChainID)
 		}
 		chainIDs[chain.ChainID] = struct{}{}
 	}
@@ -277,7 +277,7 @@ func (c RelayerConfig) validateRoutes() error {
 	return nil
 }
 
-func (c RelayerChainConfig) Validate() error {
+func (c ChainOverride) Validate() error {
 	switch {
 	case c.ChainID == "":
 		return errors.New(".chainId required")

--- a/link/internal/config/relayer.go
+++ b/link/internal/config/relayer.go
@@ -25,14 +25,14 @@ const (
 
 // RelayerConfig the relayer block of the config.
 type RelayerConfig struct {
-	ChainOverrides []ChainOverride `yaml:"chainOverrides"`
-	Clients        []ClientConfig  `yaml:"clients"`
-	Attestors      []AttestorEntry `yaml:"attestors"`
-	Routes         []RouteConfig   `yaml:"routesToRelay"`
+	ChainOverrides []RelayerChainOverride `yaml:"chainOverrides"`
+	Clients        []ClientConfig         `yaml:"clients"`
+	Attestors      []AttestorEntry        `yaml:"attestors"`
+	Routes         []RouteConfig          `yaml:"routesToRelay"`
 }
 
-// ChainOverride relay settings for one chain.
-type ChainOverride struct {
+// RelayerChainOverride relay settings for one chain.
+type RelayerChainOverride struct {
 	ChainID            string            `yaml:"chainId"`
 	EVM                *RelayerEVMConfig `yaml:"evm,omitempty"`
 	TxSubmissionDelay  *time.Duration    `yaml:"txSubmissionDelay,omitempty"`
@@ -269,7 +269,7 @@ func (c RelayerConfig) validateRoutes() error {
 	return nil
 }
 
-func (c ChainOverride) Validate() error {
+func (c RelayerChainOverride) Validate() error {
 	switch {
 	case c.ChainID == "":
 		return errors.New(".chainId required")

--- a/link/internal/config/relayer.go
+++ b/link/internal/config/relayer.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"math/big"
 	"time"
 
 	"github.com/pkg/errors"
@@ -34,24 +33,17 @@ type RelayerConfig struct {
 
 // ChainOverride relay settings for one chain.
 type ChainOverride struct {
-	ChainID            string              `yaml:"chainId"`
-	EVM                *RelayerEVMConfig   `yaml:"evm,omitempty"`
-	GasAlertThresholds *GasAlertThresholds `yaml:"gasAlertThresholds,omitempty"`
-	TxSubmissionDelay  *time.Duration      `yaml:"txSubmissionDelay,omitempty"`
-	PacketBatchSize    *int                `yaml:"packetBatchSize,omitempty"`
-	PacketBatchTimeout *time.Duration      `yaml:"packetBatchTimeout,omitempty"`
+	ChainID            string            `yaml:"chainId"`
+	EVM                *RelayerEVMConfig `yaml:"evm,omitempty"`
+	TxSubmissionDelay  *time.Duration    `yaml:"txSubmissionDelay,omitempty"`
+	PacketBatchSize    *int              `yaml:"packetBatchSize,omitempty"`
+	PacketBatchTimeout *time.Duration    `yaml:"packetBatchTimeout,omitempty"`
 }
 
 // RelayerEVMConfig EVM relaying settings.
 type RelayerEVMConfig struct {
 	GasFeeCapMultiplier *float64 `yaml:"gasFeeCapMultiplier,omitempty"`
 	GasTipCapMultiplier *float64 `yaml:"gasTipCapMultiplier,omitempty"`
-}
-
-// GasAlertThresholds gas balances that trigger low-balance metrics.
-type GasAlertThresholds struct {
-	WarningThreshold  string `yaml:"warningThreshold"`
-	CriticalThreshold string `yaml:"criticalThreshold"`
 }
 
 // ClientConfig a light client on a chain.
@@ -295,12 +287,6 @@ func (c ChainOverride) Validate() error {
 		}
 	}
 
-	if c.GasAlertThresholds != nil {
-		if err := c.GasAlertThresholds.Validate(); err != nil {
-			return errors.Wrap(err, ".gasAlertThresholds")
-		}
-	}
-
 	return nil
 }
 
@@ -310,20 +296,6 @@ func (c RelayerEVMConfig) Validate() error {
 		return errors.New(".gasFeeCapMultiplier must be positive")
 	case c.GasTipCapMultiplier != nil && *c.GasTipCapMultiplier <= 0:
 		return errors.New(".gasTipCapMultiplier must be positive")
-	}
-
-	return nil
-}
-
-func (c GasAlertThresholds) Validate() error {
-	for name, value := range map[string]string{
-		".warningThreshold":  c.WarningThreshold,
-		".criticalThreshold": c.CriticalThreshold,
-	} {
-		amount, ok := new(big.Int).SetString(value, 10)
-		if !ok || amount.Sign() < 0 {
-			return errors.Errorf("%s must be a non-negative integer, got %q", name, value)
-		}
 	}
 
 	return nil

--- a/link/internal/config/relayer.go
+++ b/link/internal/config/relayer.go
@@ -1,0 +1,390 @@
+package config
+
+import (
+	"math/big"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// ClientType the light client type.
+type ClientType string
+
+// Client types
+const (
+	ClientTypeAttestation ClientType = "attestation"
+)
+
+// AttestorType how an attestor is reached.
+type AttestorType string
+
+// Attestor types
+const (
+	AttestorTypeRemote AttestorType = "remote"
+	AttestorTypeLocal  AttestorType = "local"
+)
+
+// RelayerConfig the relayer block of the config.
+type RelayerConfig struct {
+	Chains    []RelayerChainConfig `yaml:"chains"`
+	Clients   []ClientConfig       `yaml:"clients"`
+	Attestors []AttestorEntry      `yaml:"attestors"`
+	Routes    []RouteConfig        `yaml:"routesToRelay"`
+}
+
+// RelayerChainConfig relay settings for one chain.
+type RelayerChainConfig struct {
+	ChainID            string              `yaml:"chainId"`
+	EVM                *RelayerEVMConfig   `yaml:"evm,omitempty"`
+	GasAlertThresholds *GasAlertThresholds `yaml:"gasAlertThresholds,omitempty"`
+	TxSubmissionDelay  *time.Duration      `yaml:"txSubmissionDelay,omitempty"`
+	PacketBatchSize    *int                `yaml:"packetBatchSize,omitempty"`
+	PacketBatchTimeout *time.Duration      `yaml:"packetBatchTimeout,omitempty"`
+}
+
+// RelayerEVMConfig EVM relaying settings.
+type RelayerEVMConfig struct {
+	GasFeeCapMultiplier *float64 `yaml:"gasFeeCapMultiplier,omitempty"`
+	GasTipCapMultiplier *float64 `yaml:"gasTipCapMultiplier,omitempty"`
+}
+
+// GasAlertThresholds gas balances that trigger low-balance metrics.
+type GasAlertThresholds struct {
+	WarningThreshold  string `yaml:"warningThreshold"`
+	CriticalThreshold string `yaml:"criticalThreshold"`
+}
+
+// ClientConfig a light client on a chain.
+type ClientConfig struct {
+	// Alias unique config-level handle referenced by attestors and routes.
+	Alias                string             `yaml:"alias"`
+	ClientID             string             `yaml:"clientId"`
+	ChainID              string             `yaml:"chainId"`
+	CounterpartyChainID  string             `yaml:"counterpartyChainId"`
+	CounterpartyClientID string             `yaml:"counterpartyClientId"`
+	Type                 ClientType         `yaml:"type"`
+	AttestorSet          *AttestorSetConfig `yaml:"attestorSet,omitempty"`
+}
+
+// AttestorSetConfig attestation policy for a client.
+type AttestorSetConfig struct {
+	CounterpartyChainFinalityOffset uint64 `yaml:"counterpartyChainFinalityOffset"`
+	Threshold                       int    `yaml:"threshold"`
+}
+
+// AttestorEntry an attestor the relayer queries for packet and state attestations.
+type AttestorEntry struct {
+	Name   string       `yaml:"name"`
+	Type   AttestorType `yaml:"type"`
+	GRPC   string       `yaml:"grpc,omitempty"`
+	Client string       `yaml:"client"`
+}
+
+// RouteConfig packets sent from the source client are relayed through the
+// entire packet lifecycle: recv, ack, timeout.
+type RouteConfig struct {
+	SourceClient string          `yaml:"sourceClient"`
+	AutoRelay    AutoRelayConfig `yaml:"autoRelay,omitempty"`
+}
+
+// AutoRelayConfig automatic relaying settings.
+type AutoRelayConfig struct {
+	Enabled *bool `yaml:"enabled,omitempty"`
+	// Lookback the number of blocks the relayer looks back from the latest
+	// block to check for packets to relay.
+	Lookback uint64 `yaml:"lookback,omitempty"`
+}
+
+// ClientAttestors returns the attestors associated with a client.
+func (c RelayerConfig) ClientAttestors(clientAlias string) []AttestorEntry {
+	var attestors []AttestorEntry
+
+	for _, attestor := range c.Attestors {
+		if attestor.Client == clientAlias {
+			attestors = append(attestors, attestor)
+		}
+	}
+
+	return attestors
+}
+
+// ClientByAlias returns the client config for the given alias.
+func (c RelayerConfig) ClientByAlias(alias string) (ClientConfig, bool) {
+	for _, client := range c.Clients {
+		if client.Alias == alias {
+			return client, true
+		}
+	}
+
+	return ClientConfig{}, false
+}
+
+func (c RelayerConfig) Client(chainID, clientID string) (ClientConfig, bool) {
+	for _, client := range c.Clients {
+		if client.ChainID == chainID && client.ClientID == clientID {
+			return client, true
+		}
+	}
+
+	return ClientConfig{}, false
+}
+
+// Validate validates the relayer config. Allows empty blocks.
+func (c RelayerConfig) Validate() error {
+	if err := c.validateChains(); err != nil {
+		return err
+	}
+
+	if err := c.validateClients(); err != nil {
+		return err
+	}
+
+	if err := c.validateAttestors(); err != nil {
+		return err
+	}
+
+	return c.validateRoutes()
+}
+
+func (c RelayerConfig) validateChains() error {
+	chainIDs := make(map[string]struct{})
+
+	for _, chain := range c.Chains {
+		if err := chain.Validate(); err != nil {
+			return errors.Wrapf(err, ".chains[%s]", chain.ChainID)
+		}
+
+		if _, ok := chainIDs[chain.ChainID]; ok {
+			return errors.Errorf(".chains duplicate chainId: %q", chain.ChainID)
+		}
+		chainIDs[chain.ChainID] = struct{}{}
+	}
+
+	return nil
+}
+
+func (c RelayerConfig) validateAttestors() error {
+	seen := make(map[AttestorEntry]struct{})
+
+	for i, attestor := range c.Attestors {
+		if err := attestor.Validate(); err != nil {
+			return errors.Wrapf(err, ".attestors[%d]", i)
+		}
+
+		client, ok := c.ClientByAlias(attestor.Client)
+		if !ok {
+			return errors.Errorf(".attestors[%s] references unknown client %q", attestor.Name, attestor.Client)
+		}
+
+		if client.Type != ClientTypeAttestation {
+			return errors.Errorf(
+				".attestors[%s] client %q must have type %q",
+				attestor.Name, attestor.Client, ClientTypeAttestation,
+			)
+		}
+
+		if _, ok := seen[attestor]; ok {
+			return errors.Errorf(".attestors duplicate entry: name %q client %q", attestor.Name, attestor.Client)
+		}
+		seen[attestor] = struct{}{}
+	}
+
+	for _, client := range c.Clients {
+		if client.Type != ClientTypeAttestation {
+			continue
+		}
+
+		count := len(c.ClientAttestors(client.Alias))
+		if client.AttestorSet.Threshold > count {
+			return errors.Errorf(
+				".clients[%s].attestorSet threshold %d exceeds number of attestors %d",
+				client.Alias, client.AttestorSet.Threshold, count,
+			)
+		}
+	}
+
+	return nil
+}
+
+func (c RelayerConfig) validateClients() error {
+	clients := make(map[string]struct{})
+	aliases := make(map[string]struct{})
+
+	for _, client := range c.Clients {
+		if err := client.Validate(); err != nil {
+			return errors.Wrapf(err, ".clients[%s]", client.Alias)
+		}
+
+		if _, ok := aliases[client.Alias]; ok {
+			return errors.Errorf(".clients duplicate alias: %q", client.Alias)
+		}
+		aliases[client.Alias] = struct{}{}
+
+		key := client.ChainID + "/" + client.ClientID
+		if _, ok := clients[key]; ok {
+			return errors.Errorf(".clients duplicate client %q on chain %q", client.ClientID, client.ChainID)
+		}
+		clients[key] = struct{}{}
+	}
+
+	for _, client := range c.Clients {
+		if err := c.validateCounterparty(client); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validateCounterparty ensures both sides of a connection are configured for bi-directional relaying.
+func (c RelayerConfig) validateCounterparty(client ClientConfig) error {
+	counterparty, ok := c.Client(client.CounterpartyChainID, client.CounterpartyClientID)
+	if !ok {
+		return errors.Errorf(
+			".clients[%s] counterparty client %q on chain %q must also be configured for bi-directional relaying",
+			client.Alias, client.CounterpartyClientID, client.CounterpartyChainID,
+		)
+	}
+
+	if counterparty.CounterpartyChainID != client.ChainID || counterparty.CounterpartyClientID != client.ClientID {
+		return errors.Errorf(
+			".clients[%s] counterparty client %q does not reference it back",
+			client.Alias, counterparty.Alias,
+		)
+	}
+
+	return nil
+}
+
+func (c RelayerConfig) validateRoutes() error {
+	routes := make(map[string]struct{})
+
+	for i, route := range c.Routes {
+		if err := route.Validate(); err != nil {
+			return errors.Wrapf(err, ".routesToRelay[%d]", i)
+		}
+
+		if _, ok := c.ClientByAlias(route.SourceClient); !ok {
+			return errors.Errorf(".routesToRelay[%d] references unknown client %q", i, route.SourceClient)
+		}
+
+		if _, ok := routes[route.SourceClient]; ok {
+			return errors.Errorf(".routesToRelay duplicate route for client %q", route.SourceClient)
+		}
+		routes[route.SourceClient] = struct{}{}
+	}
+
+	return nil
+}
+
+func (c RelayerChainConfig) Validate() error {
+	switch {
+	case c.ChainID == "":
+		return errors.New(".chainId required")
+	case c.TxSubmissionDelay != nil && *c.TxSubmissionDelay < 0:
+		return errors.New(".txSubmissionDelay must not be negative")
+	case c.PacketBatchSize != nil && *c.PacketBatchSize <= 0:
+		return errors.New(".packetBatchSize must be positive")
+	case c.PacketBatchTimeout != nil && *c.PacketBatchTimeout <= 0:
+		return errors.New(".packetBatchTimeout must be positive")
+	}
+
+	if c.EVM != nil {
+		if err := c.EVM.Validate(); err != nil {
+			return errors.Wrap(err, ".evm")
+		}
+	}
+
+	if c.GasAlertThresholds != nil {
+		if err := c.GasAlertThresholds.Validate(); err != nil {
+			return errors.Wrap(err, ".gasAlertThresholds")
+		}
+	}
+
+	return nil
+}
+
+func (c RelayerEVMConfig) Validate() error {
+	switch {
+	case c.GasFeeCapMultiplier != nil && *c.GasFeeCapMultiplier <= 0:
+		return errors.New(".gasFeeCapMultiplier must be positive")
+	case c.GasTipCapMultiplier != nil && *c.GasTipCapMultiplier <= 0:
+		return errors.New(".gasTipCapMultiplier must be positive")
+	}
+
+	return nil
+}
+
+func (c GasAlertThresholds) Validate() error {
+	for name, value := range map[string]string{
+		".warningThreshold":  c.WarningThreshold,
+		".criticalThreshold": c.CriticalThreshold,
+	} {
+		amount, ok := new(big.Int).SetString(value, 10)
+		if !ok || amount.Sign() < 0 {
+			return errors.Errorf("%s must be a non-negative integer, got %q", name, value)
+		}
+	}
+
+	return nil
+}
+
+func (c ClientConfig) Validate() error {
+	switch {
+	case c.Alias == "":
+		return errors.New(".alias required")
+	case c.ClientID == "":
+		return errors.New(".clientId required")
+	case c.ChainID == "":
+		return errors.New(".chainId required")
+	case c.Type != ClientTypeAttestation:
+		return errors.Errorf(".type unknown client type: %q", c.Type)
+	case c.CounterpartyChainID == "":
+		return errors.New(".counterpartyChainId required")
+	case c.CounterpartyClientID == "":
+		return errors.New(".counterpartyClientId required")
+	}
+
+	if c.Type == ClientTypeAttestation {
+		if c.AttestorSet == nil {
+			return errors.Errorf(".attestorSet required for %s clients", ClientTypeAttestation)
+		}
+
+		if err := c.AttestorSet.Validate(); err != nil {
+			return errors.Wrap(err, ".attestorSet")
+		}
+	}
+
+	return nil
+}
+
+func (c AttestorSetConfig) Validate() error {
+	if c.Threshold < 1 {
+		return errors.New(".threshold must be at least 1")
+	}
+
+	return nil
+}
+
+func (c AttestorEntry) Validate() error {
+	switch {
+	case c.Name == "":
+		return errors.New(".name required")
+	case c.Client == "":
+		return errors.New(".client required")
+	case c.Type != AttestorTypeRemote && c.Type != AttestorTypeLocal:
+		return errors.Errorf(".type unknown attestor type: %q", c.Type)
+	case c.Type == AttestorTypeRemote && c.GRPC == "":
+		return errors.New(".grpc required for remote attestors")
+	}
+
+	return nil
+}
+
+func (c RouteConfig) Validate() error {
+	if c.SourceClient == "" {
+		return errors.New(".sourceClient required")
+	}
+
+	return nil
+}

--- a/link/internal/config/relayer_test.go
+++ b/link/internal/config/relayer_test.go
@@ -1,0 +1,474 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const fullRelayerConfig = `
+server:
+  listenAddr: 0.0.0.0:3000
+db:
+  type: sqlite
+  url: ibc.db
+chains:
+  - chainId: "1"
+    type: evm
+    rpc: https://ethereum-rpc.example.com
+    evm:
+      ics26Router: "0xe20BccD900Fa1B48f46F5a483d9De063b07eDFCC"
+  - chainId: "8453"
+    type: evm
+    rpc: https://base-rpc.example.com
+    evm:
+      ics26Router: "0xe20BccD900Fa1B48f46F5a483d9De063b07eDFCC"
+relayer:
+  chains:
+    - chainId: "1"
+      evm:
+        gasFeeCapMultiplier: 1.5
+        gasTipCapMultiplier: 1.5
+      gasAlertThresholds:
+        warningThreshold: "500000000"
+        criticalThreshold: "10000000"
+      txSubmissionDelay: 2s
+      packetBatchSize: 20
+      packetBatchTimeout: 10s
+    - chainId: "8453"
+  attestors:
+    - name: "attestor-alice-base"
+      type: remote
+      grpc: attestor-alice.example.com:3000
+      client: "eth-to-base"
+    - name: "attestor-bob-base"
+      type: remote
+      grpc: attestor-bob.example.com:3000
+      client: "eth-to-base"
+    - name: "attestor-dan-base"
+      type: local
+      client: "eth-to-base"
+    - name: "attestor-dan-ethereum"
+      type: local
+      client: "base-to-eth"
+  clients:
+    - alias: "eth-to-base"
+      clientId: "base-0"
+      chainId: "1"
+      counterpartyChainId: "8453"
+      counterpartyClientId: "ethereum-0"
+      type: "attestation"
+      attestorSet:
+        counterpartyChainFinalityOffset: 1
+        threshold: 2
+    - alias: "base-to-eth"
+      clientId: "ethereum-0"
+      chainId: "8453"
+      counterpartyChainId: "1"
+      counterpartyClientId: "base-0"
+      type: "attestation"
+      attestorSet:
+        threshold: 1
+  routesToRelay:
+    - sourceClient: "eth-to-base"
+      autoRelay:
+        enabled: false
+        lookback: 100
+    - sourceClient: "base-to-eth"
+`
+
+func TestRelayerConfig(t *testing.T) {
+	t.Run("LoadFullShape", func(t *testing.T) {
+		// ARRANGE
+		path := writeTestConfig(t, fullRelayerConfig)
+
+		// ACT
+		config, err := LoadFromFile(path, true, true)
+
+		// ASSERT
+		require.NoError(t, err)
+
+		require.Len(t, config.Chains, 2)
+		assert.Equal(t, "https://ethereum-rpc.example.com", config.Chains[0].RPC)
+		assert.Equal(t, ChainTypeEVM, config.Chains[0].Type)
+
+		require.Len(t, config.Relayer.Chains, 2)
+		chain := config.Relayer.Chains[0]
+		assert.Equal(t, "0xe20BccD900Fa1B48f46F5a483d9De063b07eDFCC", config.Chains[0].EVM.ICS26Router)
+		assert.Equal(t, 2*time.Second, *chain.TxSubmissionDelay)
+		assert.Equal(t, 1.5, *chain.EVM.GasFeeCapMultiplier)
+		assert.Equal(t, "500000000", chain.GasAlertThresholds.WarningThreshold)
+		assert.Equal(t, 20, *chain.PacketBatchSize)
+		assert.Equal(t, 10*time.Second, *chain.PacketBatchTimeout)
+
+		require.Len(t, config.Relayer.Clients, 2)
+		client := config.Relayer.Clients[0]
+		assert.Equal(t, "eth-to-base", client.Alias)
+		assert.Equal(t, "base-0", client.ClientID)
+		assert.Equal(t, "1", client.ChainID)
+		assert.Equal(t, "8453", client.CounterpartyChainID)
+		assert.Equal(t, "ethereum-0", client.CounterpartyClientID)
+		assert.Equal(t, ClientTypeAttestation, client.Type)
+
+		require.Len(t, config.Relayer.Attestors, 4)
+		assert.Equal(t, AttestorTypeRemote, config.Relayer.Attestors[0].Type)
+		assert.Equal(t, "attestor-alice-base", config.Relayer.Attestors[0].Name)
+		assert.Equal(t, "eth-to-base", config.Relayer.Attestors[0].Client)
+
+		require.NotNil(t, client.AttestorSet)
+		assert.Equal(t, uint64(1), client.AttestorSet.CounterpartyChainFinalityOffset)
+		assert.Equal(t, 2, client.AttestorSet.Threshold)
+		assert.Len(t, config.Relayer.ClientAttestors("eth-to-base"), 3)
+
+		require.Len(t, config.Relayer.Routes, 2)
+		route := config.Relayer.Routes[0]
+		assert.Equal(t, "eth-to-base", route.SourceClient)
+		assert.False(t, *route.AutoRelay.Enabled)
+		assert.Equal(t, uint64(100), route.AutoRelay.Lookback)
+
+		// autoRelay omitted -> unset
+		assert.Nil(t, config.Relayer.Routes[1].AutoRelay.Enabled)
+	})
+
+	t.Run("AttestorRequiresAttestationClient", func(t *testing.T) {
+		cfg := RelayerConfig{
+			Clients: []ClientConfig{
+				{Alias: "eth-to-base", Type: "zk"},
+			},
+			Attestors: []AttestorEntry{
+				{Name: "attestor-1", Type: AttestorTypeLocal, Client: "eth-to-base"},
+			},
+		}
+
+		err := cfg.validateAttestors()
+		require.ErrorContains(t, err, `client "eth-to-base" must have type "attestation"`)
+	})
+
+	t.Run("Helpers", func(t *testing.T) {
+		// ARRANGE
+		path := writeTestConfig(t, fullRelayerConfig)
+		config, err := LoadFromFile(path, true, true)
+		require.NoError(t, err)
+
+		// ACT / ASSERT
+		_, ok := config.Chain("1")
+		assert.True(t, ok)
+
+		_, ok = config.Chain("999")
+		assert.False(t, ok)
+
+
+		client, ok := config.Relayer.Client("1", "base-0")
+		assert.True(t, ok)
+		assert.Equal(t, "8453", client.CounterpartyChainID)
+
+		_, ok = config.Relayer.Client("1", "unknown-0")
+		assert.False(t, ok)
+
+		_, ok = config.Relayer.Client("999", "base-0")
+		assert.False(t, ok)
+	})
+
+	t.Run("Validate", func(t *testing.T) {
+		for _, tt := range []struct {
+			name        string
+			patch       func(c *Config)
+			errContains string
+		}{
+			{
+				name: "empty blocks are valid",
+				patch: func(c *Config) {
+					c.Chains = nil
+					c.Relayer = RelayerConfig{}
+				},
+			},
+			{
+				name: "chain missing chainId",
+				patch: func(c *Config) {
+					c.Chains[0].ChainID = ""
+				},
+				errContains: ".chainId required",
+			},
+			{
+				name: "chain invalid type",
+				patch: func(c *Config) {
+					c.Chains[0].Type = "cosmos"
+				},
+				errContains: `unknown chain type: "cosmos"`,
+			},
+			{
+				name: "chain missing evm",
+				patch: func(c *Config) {
+					c.Chains[0].EVM = nil
+				},
+				errContains: ".evm required",
+			},
+			{
+				name: "chain missing rpc",
+				patch: func(c *Config) {
+					c.Chains[0].RPC = ""
+				},
+				errContains: ".rpc required",
+			},
+			{
+				name: "duplicate top-level chainId",
+				patch: func(c *Config) {
+					c.Chains[1].ChainID = "1"
+				},
+				errContains: "duplicate chainId",
+			},
+			{
+				name: "duplicate relayer chainId",
+				patch: func(c *Config) {
+					c.Relayer.Chains[1].ChainID = "1"
+				},
+				errContains: "duplicate chainId",
+			},
+			{
+				name: "relayer chain not declared",
+				patch: func(c *Config) {
+					c.Relayer.Chains[0].ChainID = "43"
+				},
+				errContains: "not declared in top-level chains",
+			},
+			{
+				name: "client chain not declared",
+				patch: func(c *Config) {
+					c.Relayer.Clients[0].ChainID = "999"
+				},
+				errContains: `.clients[base-0] chainId "999" not declared`,
+			},
+			{
+				name: "counterparty chain not declared",
+				patch: func(c *Config) {
+					c.Relayer.Clients[0].CounterpartyChainID = "999"
+				},
+				errContains: `counterparty client "ethereum-0" on chain "999" must also be configured`,
+			},
+			{
+				name: "client missing counterpartyClientId",
+				patch: func(c *Config) {
+					c.Relayer.Clients[0].CounterpartyClientID = ""
+				},
+				errContains: ".counterpartyClientId required",
+			},
+			{
+				name: "counterparty client not configured",
+				patch: func(c *Config) {
+					c.Relayer.Clients = c.Relayer.Clients[:1]
+					c.Relayer.Routes = c.Relayer.Routes[:1]
+				},
+				errContains: `counterparty client "ethereum-0" on chain "8453" must also be configured`,
+			},
+			{
+				name: "counterparty client does not reference back",
+				patch: func(c *Config) {
+					c.Relayer.Clients[1].CounterpartyClientID = "other-0"
+				},
+				errContains: `counterparty client "base-to-eth" does not reference it back`,
+			},
+			{
+				name: "non-positive batch size",
+				patch: func(c *Config) {
+					size := 0
+					c.Relayer.Chains[0].PacketBatchSize = &size
+				},
+				errContains: ".packetBatchSize must be positive",
+			},
+			{
+				name: "negative tx submission delay",
+				patch: func(c *Config) {
+					delay := -time.Second
+					c.Relayer.Chains[0].TxSubmissionDelay = &delay
+				},
+				errContains: ".txSubmissionDelay must not be negative",
+			},
+			{
+				name: "missing router contract",
+				patch: func(c *Config) {
+					c.Chains[0].EVM.ICS26Router = ""
+				},
+				errContains: ".evm.ics26Router required",
+			},
+			{
+				name: "zero gas multiplier",
+				patch: func(c *Config) {
+					zero := 0.0
+					c.Relayer.Chains[0].EVM.GasFeeCapMultiplier = &zero
+				},
+				errContains: ".gasFeeCapMultiplier must be positive",
+			},
+			{
+				name: "non-numeric gas threshold",
+				patch: func(c *Config) {
+					c.Relayer.Chains[0].GasAlertThresholds.WarningThreshold = "lots"
+				},
+				errContains: ".warningThreshold must be a non-negative integer",
+			},
+			{
+				name: "empty gas threshold",
+				patch: func(c *Config) {
+					c.Relayer.Chains[0].GasAlertThresholds.CriticalThreshold = ""
+				},
+				errContains: ".criticalThreshold must be a non-negative integer",
+			},
+			{
+				name: "client missing clientId",
+				patch: func(c *Config) {
+					c.Relayer.Clients[0].ClientID = ""
+				},
+				errContains: ".clientId required",
+			},
+			{
+				name: "client missing chainId",
+				patch: func(c *Config) {
+					c.Relayer.Clients[0].ChainID = ""
+				},
+				errContains: ".chainId required",
+			},
+			{
+				name: "unsupported client type",
+				patch: func(c *Config) {
+					c.Relayer.Clients[0].Type = "tendermint"
+				},
+				errContains: `unknown client type: "tendermint"`,
+			},
+			{
+				name: "duplicate client",
+				patch: func(c *Config) {
+					duplicate := c.Relayer.Clients[0]
+					duplicate.Alias = "eth-to-base-2"
+					c.Relayer.Clients = append(c.Relayer.Clients, duplicate)
+				},
+				errContains: `.clients duplicate client "base-0" on chain "1"`,
+			},
+			{
+				name: "client without attestor set",
+				patch: func(c *Config) {
+					c.Relayer.Clients[0].AttestorSet = nil
+				},
+				errContains: `.attestorSet required for attestation clients`,
+			},
+			{
+				name: "attestor references unknown client",
+				patch: func(c *Config) {
+					c.Relayer.Attestors[0].Client = "unknown"
+				},
+				errContains: `references unknown client "unknown"`,
+			},
+			{
+				name: "attestor missing client",
+				patch: func(c *Config) {
+					c.Relayer.Attestors[0].Client = ""
+				},
+				errContains: ".client required",
+			},
+			{
+				name: "client missing alias",
+				patch: func(c *Config) {
+					c.Relayer.Clients[0].Alias = ""
+				},
+				errContains: ".alias required",
+			},
+			{
+				name: "duplicate client alias",
+				patch: func(c *Config) {
+					c.Relayer.Clients[1].Alias = "eth-to-base"
+				},
+				errContains: `.clients duplicate alias`,
+			},
+			{
+				name: "threshold exceeds attestors",
+				patch: func(c *Config) {
+					c.Relayer.Clients[0].AttestorSet.Threshold = 4
+				},
+				errContains: `threshold 4 exceeds number of attestors 3`,
+			},
+			{
+				name: "zero threshold",
+				patch: func(c *Config) {
+					c.Relayer.Clients[0].AttestorSet.Threshold = 0
+				},
+				errContains: ".threshold must be at least 1",
+			},
+			{
+				name: "remote attestor missing grpc",
+				patch: func(c *Config) {
+					c.Relayer.Attestors[0].GRPC = ""
+				},
+				errContains: ".grpc required for remote attestors",
+			},
+			{
+				name: "invalid attestor type",
+				patch: func(c *Config) {
+					c.Relayer.Attestors[0].Type = "hybrid"
+				},
+				errContains: `unknown attestor type: "hybrid"`,
+			},
+			{
+				name: "attestor missing name",
+				patch: func(c *Config) {
+					c.Relayer.Attestors[0].Name = ""
+				},
+				errContains: ".name required",
+			},
+			{
+				name: "duplicate attestor name routed to a different grpc endpoint",
+				patch: func(c *Config) {
+					c.Relayer.Attestors[1].Name = "attestor-alice-base"
+				},
+			},
+			{
+				name: "duplicate attestor entry",
+				patch: func(c *Config) {
+					c.Relayer.Attestors[1] = c.Relayer.Attestors[0]
+				},
+				errContains: ".attestors duplicate entry",
+			},
+			{
+				name: "route missing sourceClient",
+				patch: func(c *Config) {
+					c.Relayer.Routes[0].SourceClient = ""
+				},
+				errContains: ".sourceClient required",
+			},
+			{
+				name: "route references unknown client",
+				patch: func(c *Config) {
+					c.Relayer.Routes[0].SourceClient = "unknown"
+				},
+				errContains: `references unknown client "unknown"`,
+			},
+			{
+				name: "duplicate route",
+				patch: func(c *Config) {
+					c.Relayer.Routes = append(c.Relayer.Routes, c.Relayer.Routes[0])
+				},
+				errContains: ".routesToRelay duplicate route",
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				// ARRANGE
+				path := writeTestConfig(t, fullRelayerConfig)
+				config, err := LoadFromFile(path, true, true)
+				require.NoError(t, err)
+
+				tt.patch(&config)
+
+				// ACT
+				err = config.Validate()
+
+				// ASSERT
+				if tt.errContains != "" {
+					require.ErrorContains(t, err, tt.errContains)
+					return
+				}
+
+				require.NoError(t, err)
+			})
+		}
+	})
+
+}

--- a/link/internal/config/relayer_test.go
+++ b/link/internal/config/relayer_test.go
@@ -41,15 +41,14 @@ func TestRelayerConfig(t *testing.T) {
 		assert.Equal(t, "ethereum-0", client.CounterpartyClientID)
 		assert.Equal(t, ClientTypeAttestation, client.Type)
 
-		require.Len(t, config.Relayer.Attestors, 4)
-		assert.Equal(t, AttestorTypeRemote, config.Relayer.Attestors[0].Type)
-		assert.Equal(t, "attestor-alice-base", config.Relayer.Attestors[0].Name)
-		assert.Equal(t, "eth-to-base", config.Relayer.Attestors[0].Client)
+		attestors := client.AttestorSet.Attestors
+		require.Len(t, attestors, 3)
+		assert.Equal(t, AttestorTypeRemote, attestors[0].Type)
+		assert.Equal(t, "attestor-alice-base", attestors[0].Name)
 
 		require.NotNil(t, client.AttestorSet)
 		assert.Equal(t, uint64(1), client.AttestorSet.CounterpartyChainFinalityOffset)
 		assert.Equal(t, 2, client.AttestorSet.Threshold)
-		assert.Len(t, config.Relayer.ClientAttestors("eth-to-base"), 3)
 
 		require.Len(t, config.Relayer.Routes, 2)
 		route := config.Relayer.Routes[0]
@@ -59,20 +58,6 @@ func TestRelayerConfig(t *testing.T) {
 
 		// autoRelay omitted -> unset
 		assert.Nil(t, config.Relayer.Routes[1].AutoRelay.Enabled)
-	})
-
-	t.Run("AttestorRequiresAttestationClient", func(t *testing.T) {
-		cfg := RelayerConfig{
-			Clients: []ClientConfig{
-				{Alias: "eth-to-base", Type: "zk"},
-			},
-			Attestors: []AttestorEntry{
-				{Name: "attestor-1", Type: AttestorTypeLocal, Client: "eth-to-base"},
-			},
-		}
-
-		err := cfg.validateAttestors()
-		require.ErrorContains(t, err, `client "eth-to-base" must have type "attestation"`)
 	})
 
 	t.Run("Helpers", func(t *testing.T) {
@@ -253,20 +238,6 @@ func TestRelayerConfig(t *testing.T) {
 				errContains: `.attestorSet required for attestation clients`,
 			},
 			{
-				name: "attestor references unknown client",
-				patch: func(c *Config) {
-					c.Relayer.Attestors[0].Client = "unknown"
-				},
-				errContains: `references unknown client "unknown"`,
-			},
-			{
-				name: "attestor missing client",
-				patch: func(c *Config) {
-					c.Relayer.Attestors[0].Client = ""
-				},
-				errContains: ".client required",
-			},
-			{
 				name: "client missing alias",
 				patch: func(c *Config) {
 					c.Relayer.Clients[0].Alias = ""
@@ -297,34 +268,34 @@ func TestRelayerConfig(t *testing.T) {
 			{
 				name: "remote attestor missing grpc",
 				patch: func(c *Config) {
-					c.Relayer.Attestors[0].GRPC = ""
+					c.Relayer.Clients[0].AttestorSet.Attestors[0].GRPC = ""
 				},
 				errContains: ".grpc required for remote attestors",
 			},
 			{
 				name: "invalid attestor type",
 				patch: func(c *Config) {
-					c.Relayer.Attestors[0].Type = "hybrid"
+					c.Relayer.Clients[0].AttestorSet.Attestors[0].Type = "hybrid"
 				},
 				errContains: `unknown attestor type: "hybrid"`,
 			},
 			{
 				name: "attestor missing name",
 				patch: func(c *Config) {
-					c.Relayer.Attestors[0].Name = ""
+					c.Relayer.Clients[0].AttestorSet.Attestors[0].Name = ""
 				},
 				errContains: ".name required",
 			},
 			{
 				name: "duplicate attestor name routed to a different grpc endpoint",
 				patch: func(c *Config) {
-					c.Relayer.Attestors[1].Name = "attestor-alice-base"
+					c.Relayer.Clients[0].AttestorSet.Attestors[1].Name = "attestor-alice-base"
 				},
 			},
 			{
 				name: "duplicate attestor entry",
 				patch: func(c *Config) {
-					c.Relayer.Attestors[1] = c.Relayer.Attestors[0]
+					c.Relayer.Clients[0].AttestorSet.Attestors[1] = c.Relayer.Clients[0].AttestorSet.Attestors[0]
 				},
 				errContains: ".attestors duplicate entry",
 			},

--- a/link/internal/config/relayer_test.go
+++ b/link/internal/config/relayer_test.go
@@ -24,7 +24,7 @@ chains:
       rpc: https://base-rpc.example.com
       ics26Router: "0xe20BccD900Fa1B48f46F5a483d9De063b07eDFCC"
 relayer:
-  chains:
+  chainOverrides:
     - chainId: "1"
       evm:
         gasFeeCapMultiplier: 1.5
@@ -92,8 +92,8 @@ func TestRelayerConfig(t *testing.T) {
 		assert.Equal(t, "https://ethereum-rpc.example.com", config.Chains[0].EVM.RPC)
 		assert.Equal(t, ChainTypeEVM, config.Chains[0].Type())
 
-		require.Len(t, config.Relayer.Chains, 2)
-		chain := config.Relayer.Chains[0]
+		require.Len(t, config.Relayer.ChainOverrides, 2)
+		chain := config.Relayer.ChainOverrides[0]
 		assert.Equal(t, "0xe20BccD900Fa1B48f46F5a483d9De063b07eDFCC", config.Chains[0].EVM.ICS26Router)
 		assert.Equal(t, 2*time.Second, *chain.TxSubmissionDelay)
 		assert.Equal(t, 1.5, *chain.EVM.GasFeeCapMultiplier)
@@ -157,7 +157,6 @@ func TestRelayerConfig(t *testing.T) {
 		_, ok = config.Chain("999")
 		assert.False(t, ok)
 
-
 		client, ok := config.Relayer.Client("1", "base-0")
 		assert.True(t, ok)
 		assert.Equal(t, "8453", client.CounterpartyChainID)
@@ -206,14 +205,14 @@ func TestRelayerConfig(t *testing.T) {
 			{
 				name: "duplicate relayer chainId",
 				patch: func(c *Config) {
-					c.Relayer.Chains[1].ChainID = "1"
+					c.Relayer.ChainOverrides[1].ChainID = "1"
 				},
 				errContains: "duplicate chainId",
 			},
 			{
 				name: "relayer chain not declared",
 				patch: func(c *Config) {
-					c.Relayer.Chains[0].ChainID = "43"
+					c.Relayer.ChainOverrides[0].ChainID = "43"
 				},
 				errContains: "not declared in top-level chains",
 			},
@@ -258,7 +257,7 @@ func TestRelayerConfig(t *testing.T) {
 				name: "non-positive batch size",
 				patch: func(c *Config) {
 					size := 0
-					c.Relayer.Chains[0].PacketBatchSize = &size
+					c.Relayer.ChainOverrides[0].PacketBatchSize = &size
 				},
 				errContains: ".packetBatchSize must be positive",
 			},
@@ -266,7 +265,7 @@ func TestRelayerConfig(t *testing.T) {
 				name: "negative tx submission delay",
 				patch: func(c *Config) {
 					delay := -time.Second
-					c.Relayer.Chains[0].TxSubmissionDelay = &delay
+					c.Relayer.ChainOverrides[0].TxSubmissionDelay = &delay
 				},
 				errContains: ".txSubmissionDelay must not be negative",
 			},
@@ -281,21 +280,21 @@ func TestRelayerConfig(t *testing.T) {
 				name: "zero gas multiplier",
 				patch: func(c *Config) {
 					zero := 0.0
-					c.Relayer.Chains[0].EVM.GasFeeCapMultiplier = &zero
+					c.Relayer.ChainOverrides[0].EVM.GasFeeCapMultiplier = &zero
 				},
 				errContains: ".gasFeeCapMultiplier must be positive",
 			},
 			{
 				name: "non-numeric gas threshold",
 				patch: func(c *Config) {
-					c.Relayer.Chains[0].GasAlertThresholds.WarningThreshold = "lots"
+					c.Relayer.ChainOverrides[0].GasAlertThresholds.WarningThreshold = "lots"
 				},
 				errContains: ".warningThreshold must be a non-negative integer",
 			},
 			{
 				name: "empty gas threshold",
 				patch: func(c *Config) {
-					c.Relayer.Chains[0].GasAlertThresholds.CriticalThreshold = ""
+					c.Relayer.ChainOverrides[0].GasAlertThresholds.CriticalThreshold = ""
 				},
 				errContains: ".criticalThreshold must be a non-negative integer",
 			},

--- a/link/internal/config/relayer_test.go
+++ b/link/internal/config/relayer_test.go
@@ -190,13 +190,6 @@ func TestRelayerConfig(t *testing.T) {
 				errContains: ".chainId required",
 			},
 			{
-				name: "chain missing evm",
-				patch: func(c *Config) {
-					c.Chains[0].EVM = nil
-				},
-				errContains: "unknown chain type",
-			},
-			{
 				name: "chain missing rpc",
 				patch: func(c *Config) {
 					c.Chains[0].EVM.RPC = ""

--- a/link/internal/config/relayer_test.go
+++ b/link/internal/config/relayer_test.go
@@ -16,14 +16,12 @@ db:
   url: ibc.db
 chains:
   - chainId: "1"
-    type: evm
-    rpc: https://ethereum-rpc.example.com
     evm:
+      rpc: https://ethereum-rpc.example.com
       ics26Router: "0xe20BccD900Fa1B48f46F5a483d9De063b07eDFCC"
   - chainId: "8453"
-    type: evm
-    rpc: https://base-rpc.example.com
     evm:
+      rpc: https://base-rpc.example.com
       ics26Router: "0xe20BccD900Fa1B48f46F5a483d9De063b07eDFCC"
 relayer:
   chains:
@@ -91,8 +89,8 @@ func TestRelayerConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, config.Chains, 2)
-		assert.Equal(t, "https://ethereum-rpc.example.com", config.Chains[0].RPC)
-		assert.Equal(t, ChainTypeEVM, config.Chains[0].Type)
+		assert.Equal(t, "https://ethereum-rpc.example.com", config.Chains[0].EVM.RPC)
+		assert.Equal(t, ChainTypeEVM, config.Chains[0].Type())
 
 		require.Len(t, config.Relayer.Chains, 2)
 		chain := config.Relayer.Chains[0]
@@ -192,25 +190,18 @@ func TestRelayerConfig(t *testing.T) {
 				errContains: ".chainId required",
 			},
 			{
-				name: "chain invalid type",
-				patch: func(c *Config) {
-					c.Chains[0].Type = "cosmos"
-				},
-				errContains: `unknown chain type: "cosmos"`,
-			},
-			{
 				name: "chain missing evm",
 				patch: func(c *Config) {
 					c.Chains[0].EVM = nil
 				},
-				errContains: ".evm required",
+				errContains: "unknown chain type",
 			},
 			{
 				name: "chain missing rpc",
 				patch: func(c *Config) {
-					c.Chains[0].RPC = ""
+					c.Chains[0].EVM.RPC = ""
 				},
-				errContains: ".rpc required",
+				errContains: ".evm.rpc required",
 			},
 			{
 				name: "duplicate top-level chainId",
@@ -237,6 +228,7 @@ func TestRelayerConfig(t *testing.T) {
 				name: "client chain not declared",
 				patch: func(c *Config) {
 					c.Relayer.Clients[0].ChainID = "999"
+					c.Relayer.Clients[1].CounterpartyChainID = "999"
 				},
 				errContains: `.clients[base-0] chainId "999" not declared`,
 			},

--- a/link/internal/config/relayer_test.go
+++ b/link/internal/config/relayer_test.go
@@ -29,9 +29,6 @@ relayer:
       evm:
         gasFeeCapMultiplier: 1.5
         gasTipCapMultiplier: 1.5
-      gasAlertThresholds:
-        warningThreshold: "500000000"
-        criticalThreshold: "10000000"
       txSubmissionDelay: 2s
       packetBatchSize: 20
       packetBatchTimeout: 10s
@@ -97,7 +94,6 @@ func TestRelayerConfig(t *testing.T) {
 		assert.Equal(t, "0xe20BccD900Fa1B48f46F5a483d9De063b07eDFCC", config.Chains[0].EVM.ICS26Router)
 		assert.Equal(t, 2*time.Second, *chain.TxSubmissionDelay)
 		assert.Equal(t, 1.5, *chain.EVM.GasFeeCapMultiplier)
-		assert.Equal(t, "500000000", chain.GasAlertThresholds.WarningThreshold)
 		assert.Equal(t, 20, *chain.PacketBatchSize)
 		assert.Equal(t, 10*time.Second, *chain.PacketBatchTimeout)
 
@@ -283,20 +279,6 @@ func TestRelayerConfig(t *testing.T) {
 					c.Relayer.ChainOverrides[0].EVM.GasFeeCapMultiplier = &zero
 				},
 				errContains: ".gasFeeCapMultiplier must be positive",
-			},
-			{
-				name: "non-numeric gas threshold",
-				patch: func(c *Config) {
-					c.Relayer.ChainOverrides[0].GasAlertThresholds.WarningThreshold = "lots"
-				},
-				errContains: ".warningThreshold must be a non-negative integer",
-			},
-			{
-				name: "empty gas threshold",
-				patch: func(c *Config) {
-					c.Relayer.ChainOverrides[0].GasAlertThresholds.CriticalThreshold = ""
-				},
-				errContains: ".criticalThreshold must be a non-negative integer",
 			},
 			{
 				name: "client missing clientId",

--- a/link/internal/config/relayer_test.go
+++ b/link/internal/config/relayer_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -8,76 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const fullRelayerConfig = `
-server:
-  listenAddr: 0.0.0.0:3000
-db:
-  type: sqlite
-  url: ibc.db
-chains:
-  - chainId: "1"
-    evm:
-      rpc: https://ethereum-rpc.example.com
-      ics26Router: "0xe20BccD900Fa1B48f46F5a483d9De063b07eDFCC"
-  - chainId: "8453"
-    evm:
-      rpc: https://base-rpc.example.com
-      ics26Router: "0xe20BccD900Fa1B48f46F5a483d9De063b07eDFCC"
-relayer:
-  chainOverrides:
-    - chainId: "1"
-      evm:
-        gasFeeCapMultiplier: 1.5
-        gasTipCapMultiplier: 1.5
-      txSubmissionDelay: 2s
-      packetBatchSize: 20
-      packetBatchTimeout: 10s
-    - chainId: "8453"
-  attestors:
-    - name: "attestor-alice-base"
-      type: remote
-      grpc: attestor-alice.example.com:3000
-      client: "eth-to-base"
-    - name: "attestor-bob-base"
-      type: remote
-      grpc: attestor-bob.example.com:3000
-      client: "eth-to-base"
-    - name: "attestor-dan-base"
-      type: local
-      client: "eth-to-base"
-    - name: "attestor-dan-ethereum"
-      type: local
-      client: "base-to-eth"
-  clients:
-    - alias: "eth-to-base"
-      clientId: "base-0"
-      chainId: "1"
-      counterpartyChainId: "8453"
-      counterpartyClientId: "ethereum-0"
-      type: "attestation"
-      attestorSet:
-        counterpartyChainFinalityOffset: 1
-        threshold: 2
-    - alias: "base-to-eth"
-      clientId: "ethereum-0"
-      chainId: "8453"
-      counterpartyChainId: "1"
-      counterpartyClientId: "base-0"
-      type: "attestation"
-      attestorSet:
-        threshold: 1
-  routesToRelay:
-    - sourceClient: "eth-to-base"
-      autoRelay:
-        enabled: false
-        lookback: 100
-    - sourceClient: "base-to-eth"
-`
-
 func TestRelayerConfig(t *testing.T) {
 	t.Run("LoadFullShape", func(t *testing.T) {
 		// ARRANGE
-		path := writeTestConfig(t, fullRelayerConfig)
+		path := filepath.Join("testdata", "sample.yml")
 
 		// ACT
 		config, err := LoadFromFile(path, true, true)
@@ -142,7 +77,7 @@ func TestRelayerConfig(t *testing.T) {
 
 	t.Run("Helpers", func(t *testing.T) {
 		// ARRANGE
-		path := writeTestConfig(t, fullRelayerConfig)
+		path := filepath.Join("testdata", "sample.yml")
 		config, err := LoadFromFile(path, true, true)
 		require.NoError(t, err)
 
@@ -417,7 +352,7 @@ func TestRelayerConfig(t *testing.T) {
 		} {
 			t.Run(tt.name, func(t *testing.T) {
 				// ARRANGE
-				path := writeTestConfig(t, fullRelayerConfig)
+				path := filepath.Join("testdata", "sample.yml")
 				config, err := LoadFromFile(path, true, true)
 				require.NoError(t, err)
 

--- a/link/internal/config/testdata/sample.yml
+++ b/link/internal/config/testdata/sample.yml
@@ -22,21 +22,6 @@ relayer:
       packetBatchSize: 20
       packetBatchTimeout: 10s
     - chainId: "8453"
-  attestors:
-    - name: "attestor-alice-base"
-      type: remote
-      grpc: attestor-alice.example.com:3000
-      client: "eth-to-base"
-    - name: "attestor-bob-base"
-      type: remote
-      grpc: attestor-bob.example.com:3000
-      client: "eth-to-base"
-    - name: "attestor-dan-base"
-      type: local
-      client: "eth-to-base"
-    - name: "attestor-dan-ethereum"
-      type: local
-      client: "base-to-eth"
   clients:
     - alias: "eth-to-base"
       clientId: "base-0"
@@ -47,6 +32,15 @@ relayer:
       attestorSet:
         counterpartyChainFinalityOffset: 1
         threshold: 2
+        attestors:
+          - name: "attestor-alice-base"
+            type: remote
+            grpc: attestor-alice.example.com:3000
+          - name: "attestor-bob-base"
+            type: remote
+            grpc: attestor-bob.example.com:3000
+          - name: "attestor-dan-base"
+            type: local
     - alias: "base-to-eth"
       clientId: "ethereum-0"
       chainId: "8453"
@@ -55,6 +49,9 @@ relayer:
       type: "attestation"
       attestorSet:
         threshold: 1
+        attestors:
+          - name: "attestor-dan-ethereum"
+            type: local
   routesToRelay:
     - sourceClient: "eth-to-base"
       autoRelay:

--- a/link/internal/config/testdata/sample.yml
+++ b/link/internal/config/testdata/sample.yml
@@ -1,0 +1,63 @@
+server:
+  listenAddr: 0.0.0.0:3000
+db:
+  type: sqlite
+  url: ibc.db
+chains:
+  - chainId: "1"
+    evm:
+      rpc: https://ethereum-rpc.example.com
+      ics26Router: "0xe20BccD900Fa1B48f46F5a483d9De063b07eDFCC"
+  - chainId: "8453"
+    evm:
+      rpc: https://base-rpc.example.com
+      ics26Router: "0xe20BccD900Fa1B48f46F5a483d9De063b07eDFCC"
+relayer:
+  chainOverrides:
+    - chainId: "1"
+      evm:
+        gasFeeCapMultiplier: 1.5
+        gasTipCapMultiplier: 1.5
+      txSubmissionDelay: 2s
+      packetBatchSize: 20
+      packetBatchTimeout: 10s
+    - chainId: "8453"
+  attestors:
+    - name: "attestor-alice-base"
+      type: remote
+      grpc: attestor-alice.example.com:3000
+      client: "eth-to-base"
+    - name: "attestor-bob-base"
+      type: remote
+      grpc: attestor-bob.example.com:3000
+      client: "eth-to-base"
+    - name: "attestor-dan-base"
+      type: local
+      client: "eth-to-base"
+    - name: "attestor-dan-ethereum"
+      type: local
+      client: "base-to-eth"
+  clients:
+    - alias: "eth-to-base"
+      clientId: "base-0"
+      chainId: "1"
+      counterpartyChainId: "8453"
+      counterpartyClientId: "ethereum-0"
+      type: "attestation"
+      attestorSet:
+        counterpartyChainFinalityOffset: 1
+        threshold: 2
+    - alias: "base-to-eth"
+      clientId: "ethereum-0"
+      chainId: "8453"
+      counterpartyChainId: "1"
+      counterpartyClientId: "base-0"
+      type: "attestation"
+      attestorSet:
+        threshold: 1
+  routesToRelay:
+    - sourceClient: "eth-to-base"
+      autoRelay:
+        enabled: false
+        lookback: 100
+    - sourceClient: "base-to-eth"


### PR DESCRIPTION
Adds configs required for the Relayer. Defines a chains config at the top level of the config with configs shared by the relayer and attestor, and defines a relayer block with relayer-specific configs. 

Closes FOU-644